### PR TITLE
Rename "strtab" and "symtab" to ".strtab" and ".symtab".

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -338,8 +338,8 @@ impl Elf {
                 (idx, offset)
             };
 
-            push_strtab("strtab");
-            push_strtab("symtab");
+            push_strtab(".strtab");
+            push_strtab(".symtab");
             let (idx, offset) = push_strtab(&name);
             // NOTE: using 0 as the idx is a hack;
             // but we need to insert a null symbol as the first symbol, otherwise linkers explode


### PR DESCRIPTION
These are the names specified in the SysV ELF ABI.