### PR TITLE
First cut at specializing data decls/defns

### DIFF
--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -49,6 +49,8 @@ pub enum ArtifactError {
 pub struct Prop {
     pub global: bool,
     pub function: bool,
+    pub writeable: bool,
+    pub cstring: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -69,8 +71,10 @@ pub enum Decl {
     DataImport,
     /// A function defined in this artifact
     Function { global: bool },
-    /// An data object defined in this artifact
-    Data { global: bool },
+    /// A data object defined in this artifact
+    Data { global: bool, writeable: bool },
+    /// A null-terminated string object defined in this artifact
+    CString { global: bool }
 }
 
 impl Decl {
@@ -262,8 +266,9 @@ impl Artifact {
         match self.declarations.get(&decl_name) {
             Some(ref stype) => {
                 let prop = match *stype {
-                    &Decl::Data { global } => Prop { global, function: false },
-                    &Decl::Function { global } => Prop { global, function: true },
+                    &Decl::CString { global } => Prop { global, function: false, writeable: false, cstring: true },
+                    &Decl::Data { global, writeable } => Prop { global, function: false, writeable, cstring: false },
+                    &Decl::Function { global } => Prop { global, function: true, writeable: false, cstring: false},
                     _ if stype.is_import() => return Err(ArtifactError::ImportDefined(name.as_ref().to_string()).into()),
                     _ => unimplemented!("New Decl variant added but not covered in define method"),
                 };

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -62,7 +62,7 @@ fn run (args: Args) -> Result<(), Error> {
         [
             ("deadbeef", Decl::Function { global: false }),
             ("main",     Decl::Function { global: true }),
-            ("str.1",    Decl::Data { global: false }),
+            ("str.1",    Decl::CString { global: false }),
             ("DEADBEEF", Decl::DataImport),
             ("printf",   Decl::FunctionImport),
         ].into_iter().cloned()
@@ -144,7 +144,7 @@ fn deadbeef (args: Args) -> Result<(), Error> {
     // FIXME: need to state this isn't a string, but some linkers don't seem to care \o/
     // gold complains though:
     // ld.gold: warning: deadbeef.o: last entry in mergeable string section '.data.DEADBEEF' not null terminated
-    obj.declare("DEADBEEF", Decl::Data { global: true })?;
+    obj.declare("DEADBEEF", Decl::Data { global: true, writeable: false })?;
     obj.define("DEADBEEF", [0xef, 0xbe, 0xad, 0xde].to_vec())?;
     if args.mach {
         obj.write::<Mach>(file)?;

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -545,6 +545,7 @@ fn build_relocations(artifact: &Artifact, symtab: &SymbolTable) -> Relocations {
         let reloc = match link.to.decl {
             &Decl::Function {..} => X86_64_RELOC_BRANCH,
             &Decl::Data {..} => X86_64_RELOC_SIGNED,
+            &Decl::CString {..} => X86_64_RELOC_SIGNED,
             &Decl::FunctionImport => X86_64_RELOC_BRANCH,
             &Decl::DataImport => X86_64_RELOC_GOT_LOAD,
         };


### PR DESCRIPTION
This PR is a first cut at addressing https://github.com/m4b/faerie/issues/20 and maybe makes a start toward addressing https://github.com/m4b/faerie/issues/17. Hightlights:

- Adds a new datum to `Data` that determines whether the corresponding ELF section should have the writeable flag set (`writeable`)
    - Adds corresponding changes to `Prop`; I think this obeys the warning [here](http://github.com/jfoote/faerie/blob/master/src/artifact.rs#L37) since the change does not reorder the fields
- Assumes `Data` should not be mergeable and `CString` should be mergeable
- Does not address the alignment comment on https://github.com/m4b/faerie/issues/17
    - I wasn't quite sure what you had in mind here
	- The code does not assert/ensure the defined string is null-terminated
- I didn't add any tests
- I'm new to Rust so the code conventions might be janky