### PR TITLE
RelocOverride: addend needs to be signed

### DIFF
--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -12,7 +12,7 @@ use {Target, Data};
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
 pub struct RelocOverride {
     pub elftype: u32,
-    pub addend: u32,
+    pub addend: i32,
 }
 
 type Relocation = (String, String, usize, Option<RelocOverride>);


### PR DESCRIPTION
I goofed when I designed `RelocOverride` - the addend needs to be signed. (More often than not, it is negative.) Fortunately its a one-character change.