### PR TITLE
Make import(...) really just sugar for declare(...)

### DIFF
--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -392,7 +392,6 @@ impl Artifact {
     /// Declare `import` to be an import with `kind`.
     /// This is just sugar for `declare("name", Decl::FunctionImport)` or `declare("data", Decl::DataImport)`
     pub fn import<T: AsRef<str>>(&mut self, import: T, kind: ImportKind) -> Result<(), Error> {
-        let import_id = self.strings.get_or_intern(import.as_ref());
         self.declare(
             import.as_ref(),
             match &kind {
@@ -400,7 +399,6 @@ impl Artifact {
                 &ImportKind::Data => Decl::DataImport,
             },
         )?;
-        self.imports.push((import_id, kind));
         Ok(())
     }
     /// Link a relocation at `link.at` from `link.from` to `link.to`

--- a/tests/artifact.rs
+++ b/tests/artifact.rs
@@ -105,3 +105,11 @@ fn import_declarations_work_with_redeclarations() {
     let imports = obj.imports().collect::<Vec<_>>();
     assert_eq!(imports.len(), 1);
 }
+
+#[test]
+fn import_helper_adds_declaration_only_once() {
+    let mut obj = Artifact::new(Target::X86_64, "t.o".into());
+    obj.import("f", faerie::ImportKind::Function).expect("can import");
+    let imports = obj.imports().collect::<Vec<_>>();
+    assert_eq!(imports.len(), 1);
+}


### PR DESCRIPTION
This removes adding the import to Artifact::imports twice.  It's already handled by declare.

This fixes #26 