### PR TITLE
Add clone derivations; elaborate linking error

### DIFF
--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -49,7 +49,7 @@ pub enum ArtifactError {
 //   _and then_ global definitions
 ///////////////////////////////////////////////
 /// The properties associated with a symbolic reference
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub struct Prop {
     pub global: bool,
     pub function: bool,
@@ -57,7 +57,7 @@ pub struct Prop {
     pub cstring: bool,
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 struct InternalDefinition {
     prop: Prop,
     name: StringID,
@@ -251,7 +251,7 @@ impl ArtifactBuilder {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// An abstract binary artifact, which contains code, data, imports, and relocations
 pub struct Artifact {
     /// The name of this artifact

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -462,8 +462,10 @@ impl<'a> Elf<'a> {
         let (from_idx, to_idx) = {
             let to_idx = self.strings.get_or_intern(to);
             let from_idx = self.strings.get_or_intern(from);
-            let (to_idx, _, _) = self.symbols.get_pair_index(&to_idx).unwrap();
-            let (from_idx, _, _) = self.symbols.get_pair_index(&from_idx).unwrap();
+            let (to_idx, _, _) = self.symbols.get_pair_index(&to_idx)
+                .expect(&format!("link could not find symbol pair for \"{}\" at to_idx {}", to, to_idx));
+            let (from_idx, _, _) = self.symbols.get_pair_index(&from_idx)
+                .expect(&format!("link could not find symbol pair for \"{}\" at from_idx {}", from, from_idx));
             (from_idx, to_idx)
         };
 


### PR DESCRIPTION
The clone derivations are, I think, harmless. They're handy for testing etc.

I hit the `unwrap()` panic in `Elf::link` because I had incorrectly declared a symbol. I wasn't sure if changing the signature to `Result<(), Error>` was appropriate so I just added the reason to `expect`.