### PR TITLE
Ensure all artifact symbols are defined before emitting object

### DIFF
--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -450,16 +450,18 @@ impl Artifact {
     /// Get set of non-import declarations that have not been defined. This must be an empty set in
     /// order to `emit` the artifact.
     pub fn undefined_symbols(&self) -> Vec<String> {
+        let mut decls = self.declarations.clone();
+        for def in self.definitions.iter() {
+            decls.remove(&def.name);
+        }
+
         let mut syms = Vec::new();
-        for (&name, &decl) in self.declarations.iter() {
+        for (&name, &decl) in decls.iter() {
             match decl {
-                Decl::FunctionImport => {},
-                Decl::DataImport => {},
-                Decl::Function { .. } | Decl::Data { .. } | Decl::CString { .. }=> {
-                    if self.definitions.iter().find(|def| def.name == name).is_none() {
-                        syms.push(String::from(self.strings.resolve(name).expect("declaration has a name")));
-                    }
-                },
+                Decl::FunctionImport | Decl::DataImport => {},
+                Decl::Function { .. } | Decl::Data { .. } | Decl::CString { .. } => {
+                    syms.push(String::from(self.strings.resolve(name).expect("declaration has a name")));
+                }
             }
         }
         syms

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -37,6 +37,8 @@ pub enum ArtifactError {
     #[fail(display = "Incompatible declarations, old declaration {:?} is incompatible with new {:?}", old, new)]
     /// An incompatble declaration occurred, please see the [absorb](enum.Decl.html#method.absorb) method on `Decl`
     IncompatibleDeclaration { old: Decl, new: Decl },
+    #[fail(display = "duplicate definition of symbol: {}", _0)]
+    DuplicateDefinition(String),
 }
 
 ///////////////////////////////////////////////
@@ -157,6 +159,27 @@ impl Decl {
     }
 }
 
+/// A declaration, plus a flag to track whether we have a definition for it yet
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+struct InternalDecl {
+    decl: Decl,
+    defined: bool,
+}
+
+impl InternalDecl {
+    /// Wrap up a declaration. Initially marked as not defined.
+    pub fn new(decl: Decl) -> Self {
+        Self {
+            decl: decl,
+            defined: false,
+        }
+    }
+    /// Mark a declaration as defined.
+    pub fn define(&mut self) {
+        self.defined = true;
+    }
+}
+
 /// A binding of a raw `name` to its declaration, `decl`
 pub(crate) struct Binding<'a> {
     pub name: &'a str,
@@ -271,7 +294,7 @@ pub struct Artifact {
     imports: Vec<(StringID, ImportKind)>,
     import_links: Vec<Relocation>,
     links: Vec<Relocation>,
-    declarations: IndexMap<StringID, Decl>,
+    declarations: IndexMap<StringID, InternalDecl>,
     definitions: BTreeSet<InternalDefinition>,
     strings: DefaultStringInterner,
 }
@@ -307,8 +330,8 @@ impl Artifact {
             // FIXME: I think its safe to unwrap since the links are only ever constructed by us and we
             // ensure it has a declaration
             let (ref from_decl, ref to_decl) = (self.declarations.get(from).expect("declaration present"), self.declarations.get(to).unwrap());
-            let from = Binding { name: self.strings.resolve(*from).expect("from link"), decl: from_decl};
-            let to = Binding { name: self.strings.resolve(*to).expect("to link"), decl: to_decl};
+            let from = Binding { name: self.strings.resolve(*from).expect("from link"), decl: &from_decl.decl};
+            let to = Binding { name: self.strings.resolve(*to).expect("to link"), decl: &to_decl.decl};
             LinkAndDecl {
                 from,
                 to,
@@ -329,14 +352,14 @@ impl Artifact {
     pub fn declare<T: AsRef<str>>(&mut self, name: T, decl: Decl) -> Result<(), Error> {
         let decl_name = self.strings.get_or_intern(name.as_ref());
         let previous_was_import;
-        let new_decl = {
-            let previous_decl = self.declarations.entry(decl_name).or_insert(decl.clone());
-            previous_was_import = previous_decl.is_import();
-            previous_decl.absorb(decl)?;
-            &*previous_decl
+        let new_idecl = {
+            let previous = self.declarations.entry(decl_name).or_insert(InternalDecl::new(decl.clone()));
+            previous_was_import = previous.decl.is_import();
+            previous.decl.absorb(decl)?;
+            previous
         };
-        match new_decl {
-            &Decl::DataImport | &Decl::FunctionImport => {
+        match new_idecl.decl {
+            Decl::DataImport | Decl::FunctionImport => {
                 // we have to check because otherwise duplicate imports cause an error
                 // FIXME: ditto fixme, below, use orderset
                 let mut present = false;
@@ -346,7 +369,7 @@ impl Artifact {
                     }
                 }
                 if !present {
-                    let kind = ImportKind::from_decl(new_decl)
+                    let kind = ImportKind::from_decl(&new_idecl.decl)
                         .expect("can convert from explicitly matched decls to importkind");
                     self.imports.push((decl_name, kind));
                 }
@@ -382,13 +405,16 @@ impl Artifact {
     /// If you attempt to define something which has not been declared, this will return an error.
     pub fn define<T: AsRef<str>>(&mut self, name: T, data: Vec<u8>) -> Result<(), ArtifactError> {
         let decl_name = self.strings.get_or_intern(name.as_ref());
-        match self.declarations.get(&decl_name) {
-            Some(ref stype) => {
-                let prop = match *stype {
-                    &Decl::CString { global } => Prop { global, function: false, writeable: false, cstring: true },
-                    &Decl::Data { global, writeable } => Prop { global, function: false, writeable, cstring: false },
-                    &Decl::Function { global } => Prop { global, function: true, writeable: false, cstring: false},
-                    _ if stype.is_import() => return Err(ArtifactError::ImportDefined(name.as_ref().to_string()).into()),
+        match self.declarations.get_mut(&decl_name) {
+            Some(ref mut stype) => {
+                if stype.defined {
+                    return Err(ArtifactError::DuplicateDefinition(name.as_ref().to_string()));
+                }
+                let prop = match stype.decl {
+                    Decl::CString { global } => Prop { global, function: false, writeable: false, cstring: true },
+                    Decl::Data { global, writeable } => Prop { global, function: false, writeable, cstring: false },
+                    Decl::Function { global } => Prop { global, function: true, writeable: false, cstring: false},
+                    _ if stype.decl.is_import() => return Err(ArtifactError::ImportDefined(name.as_ref().to_string()).into()),
                     _ => unimplemented!("New Decl variant added but not covered in define method"),
                 };
                 self.definitions.insert(InternalDefinition {
@@ -396,6 +422,7 @@ impl Artifact {
                     data,
                     prop,
                 });
+                stype.define();
             }
             None => return Err(ArtifactError::Undeclared(name.as_ref().to_string())),
         }
@@ -430,7 +457,7 @@ impl Artifact {
         let (link_from, link_to) = (self.strings.get_or_intern(link.from), self.strings.get_or_intern(link.to));
         match (self.declarations.get(&link_from), self.declarations.get(&link_to)) {
             (Some(ref from_type), Some(_)) => {
-                if from_type.is_import() {
+                if from_type.decl.is_import() {
                     return Err(ArtifactError::RelocateImport(link.from.to_string()).into());
                 }
                 let link = (link_from, link_to, link.at, reloc);
@@ -450,19 +477,9 @@ impl Artifact {
     /// Get set of non-import declarations that have not been defined. This must be an empty set in
     /// order to `emit` the artifact.
     pub fn undefined_symbols(&self) -> Vec<String> {
-        let mut decls = self.declarations.clone();
-        for def in self.definitions.iter() {
-            decls.remove(&def.name);
-        }
-
         let mut syms = Vec::new();
-        for (&name, &decl) in decls.iter() {
-            match decl {
-                Decl::FunctionImport | Decl::DataImport => {},
-                Decl::Function { .. } | Decl::Data { .. } | Decl::CString { .. } => {
-                    syms.push(String::from(self.strings.resolve(name).expect("declaration has a name")));
-                }
-            }
+        for (&name, _) in self.declarations.iter().filter(|&(_, &int)| !int.defined && !int.decl.is_import()) {
+            syms.push(String::from(self.strings.resolve(name).expect("declaration has a name")));
         }
         syms
     }

--- a/tests/artifact.rs
+++ b/tests/artifact.rs
@@ -113,3 +113,22 @@ fn import_helper_adds_declaration_only_once() {
     let imports = obj.imports().collect::<Vec<_>>();
     assert_eq!(imports.len(), 1);
 }
+
+#[test]
+fn undefined_symbols() {
+    let mut obj = Artifact::new(Target::X86_64, "t.o".into());
+    obj.declarations(vec![
+        ("f", faerie::Decl::Function { global: true }),
+        ("g", faerie::Decl::Function { global: false }),
+    ].into_iter()
+    ).expect("can declare");
+    assert_eq!(obj.undefined_symbols(),
+        vec![String::from("f"), String::from("g")]);
+
+    obj.define("g", vec![1, 2, 3, 4]).expect("can define");
+    assert_eq!(obj.undefined_symbols(),
+        vec![String::from("f")]);
+
+    obj.define("f", vec![4, 3, 2, 1]).expect("can define");
+    assert!(obj.undefined_symbols().is_empty());
+}

--- a/tests/artifact.rs
+++ b/tests/artifact.rs
@@ -65,17 +65,16 @@ fn multiple_different_declarations_are_not_ok() {
 }
 
 #[test]
-#[should_panic]
 fn multiple_different_conflicting_declarations_are_not_ok_and_do_not_overwrite() {
     let mut obj = Artifact::new(Target::X86_64, "t.o".into());
-    obj.declarations(vec![
+    assert!(obj.declarations(vec![
         ("f", faerie::Decl::FunctionImport),
         ("f", faerie::Decl::Function { global: true }),
         ("f", faerie::Decl::FunctionImport),
         ("f", faerie::Decl::FunctionImport),
         ("f", faerie::Decl::Function { global: false }),
     ].into_iter()
-    ).expect("multiple conflicting declarations are not ok");
+    ).is_err()); // multiple conflicting declarations are not ok
 }
 
 #[test]

--- a/tests/artifact.rs
+++ b/tests/artifact.rs
@@ -114,6 +114,25 @@ fn import_helper_adds_declaration_only_once() {
 }
 
 #[test]
+fn reject_duplicate_definitions() {
+    let mut obj = Artifact::new(Target::X86_64, "t.o".into());
+    obj.declarations(vec![
+        ("f", faerie::Decl::Function { global: true }),
+        ("g", faerie::Decl::Function { global: false }),
+    ].into_iter()
+    ).expect("can declare");
+
+    obj.define("g", vec![1, 2, 3, 4]).expect("can define");
+    // Reject duplicate definition:
+    assert!(obj.define("g", vec![1, 2, 3, 4]).is_err());
+
+    obj.define("f", vec![4, 3, 2, 1]).expect("can define");
+    // Reject duplicate definitions:
+    assert!(obj.define("g", vec![1, 2, 3, 4]).is_err());
+    assert!(obj.define("f", vec![1, 2, 3, 4]).is_err());
+}
+
+#[test]
 fn undefined_symbols() {
     let mut obj = Artifact::new(Target::X86_64, "t.o".into());
     obj.declarations(vec![

--- a/tests/elf.rs
+++ b/tests/elf.rs
@@ -53,7 +53,7 @@ fn link_symbol_pair_panic_issue_30() {
         at: 0,
     }).expect("can link from b to a");
 
-    assert_eq!(obj.undefined_symbols().len(), 1);
+    assert_eq!(obj.undefined_symbols(), vec![String::from("a")]);
 
     // The `emit` method will check that there are undefined symbols
     // and return an error describing them:

--- a/tests/elf.rs
+++ b/tests/elf.rs
@@ -6,6 +6,7 @@ use faerie::{Artifact, Decl, Target, Link};
 use goblin::elf::*;
 
 #[test]
+// This test is for a known bug (issue #31). When it is fixed, this test should pass.
 #[should_panic]
 fn file_name_is_same_as_symbol_name_issue_31() {
     const NAME: &str = "a";
@@ -17,6 +18,7 @@ fn file_name_is_same_as_symbol_name_issue_31() {
     let bytes = bytes.as_slice();
     println!("{:?}", bytes);
 
+    // Presently, the following expect fails, `bytes` is not a valid Elf:
     let elf = goblin::Object::parse(&bytes).expect("can parse elf file");
     match elf {
         goblin::Object::Elf(elf) => {
@@ -36,6 +38,7 @@ fn file_name_is_same_as_symbol_name_issue_31() {
 }
 
 #[test]
+// This test is for a known bug (issue #30). When it is fixed, this test should pass.
 #[should_panic]
 fn link_symbol_pair_panic_issue_30() {
     let mut obj = Artifact::new(Target::X86_64, "t.o".into());
@@ -48,6 +51,7 @@ fn link_symbol_pair_panic_issue_30() {
         at: 0,
     }).expect("can link from b to a");
 
+    // Presently, a panic happens inside `emit`:
     let bytes = obj.emit::<faerie::Elf>().expect("Can emit object bytes");
     let elf = goblin::Object::parse(&bytes).expect("can parse elf file");
     match elf {

--- a/tests/elf.rs
+++ b/tests/elf.rs
@@ -38,27 +38,24 @@ fn file_name_is_same_as_symbol_name_issue_31() {
 }
 
 #[test]
-// This test is for a known bug (issue #30). When it is fixed, this test should pass.
-#[should_panic]
+// Regression test for issue 30: previously, if a non-import symbol was declared but not defined,
+// the elf emit function would panic
 fn link_symbol_pair_panic_issue_30() {
     let mut obj = Artifact::new(Target::X86_64, "t.o".into());
 
     obj.declare("a", Decl::Function { global: true }).expect("can declare a");
     obj.declare_with("b", Decl::Function { global: true }, vec![1, 2, 3, 4]).expect("can declare and define b");
+
+
     obj.link(Link {
         to: "a",
         from: "b",
         at: 0,
     }).expect("can link from b to a");
 
-    // Presently, a panic happens inside `emit`:
-    let bytes = obj.emit::<faerie::Elf>().expect("Can emit object bytes");
-    let elf = goblin::Object::parse(&bytes).expect("can parse elf file");
-    match elf {
-        goblin::Object::Elf(elf) => {
-            assert_eq!(elf.syms.len(), 5);
-        },
-        _ => assert!(false)
-    }
+    assert_eq!(obj.undefined_symbols().len(), 1);
 
+    // The `emit` method will check that there are undefined symbols
+    // and return an error describing them:
+    assert!(obj.emit::<faerie::Elf>().is_err());
 }


### PR DESCRIPTION
Fixes #30 

Adds a new method `Artifact::undefined_symbols` that gives the set of non-import declarations that have no definitions. Ensures that this is an empty set in the `emit` method.

Additionally, prevents duplicate definitions of symbols.