### PR TITLE
Use `write_all` instead of `write`.

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -548,7 +548,7 @@ impl<'a> Elf<'a> {
         /////////////////////////////////////
 
         for (_idx, bytes) in self.code.drain(..) {
-            file.write(bytes)?;
+            file.write_all(bytes)?;
         }
         let after_code = file.seek(Current(0))?;
         debug!("after_code {:#x}, expect: {:#x} - {}", after_code, strtab_offset, after_code == strtab_offset);
@@ -583,7 +583,7 @@ impl<'a> Elf<'a> {
         file.iowrite(0u8)?; // for the null value in the strtab;
         for (_id, string) in self.strings.iter() {
             debug!("String: {:?}", string);
-            file.write(string.as_bytes())?;
+            file.write_all(string.as_bytes())?;
             file.iowrite(0u8)?;
         }
         let after_strtab = file.seek(Current(0))?;

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -474,7 +474,7 @@ impl<'a> Mach<'a> {
         // write load commands
         //////////////////////////////
         file.iowrite_with(segment_load_command, self.ctx)?;
-        file.write(&raw_sections)?;
+        file.write_all(&raw_sections)?;
         file.iowrite_with(symtab_load_command, self.ctx.le)?;
         debug!("SEEK: after load commands: {}", file.seek(Current(0))?);
 
@@ -482,7 +482,7 @@ impl<'a> Mach<'a> {
         // write code
         //////////////////////////////
         for code in self.code {
-            file.write(code.data)?;
+            file.write_all(code.data)?;
         }
         debug!("SEEK: after code: {}", file.seek(Current(0))?);
 
@@ -490,7 +490,7 @@ impl<'a> Mach<'a> {
         // write data
         //////////////////////////////
         for data in self.data {
-            file.write(data.data)?;
+            file.write_all(data.data)?;
         }
         debug!("SEEK: after data: {}", file.seek(Current(0))?);
 
@@ -513,7 +513,7 @@ impl<'a> Mach<'a> {
             debug!("{}: {:?}", idx, string);
             // yup, an underscore
             file.iowrite(0x5fu8)?;
-            file.write(string.as_bytes())?;
+            file.write_all(string.as_bytes())?;
             file.iowrite(0u8)?;
         }
         debug!("SEEK: after strtable: {}", file.seek(Current(0))?);


### PR DESCRIPTION
`write` isn't guaranteed to write all of the bytes; it returns a size
saying how many bytes are written, and expects callers to cope with that
number being less than the requested size. Use `write_all` instead,
which either writes the requested size, or returns an error.

See also:
 - https://doc.rust-lang.org/std/io/trait.Write.html#tymethod.write
 - https://doc.rust-lang.org/std/io/trait.Write.html#method.write_all