### PR TITLE
Change relocations in data sections to be absolute and pointer-sized

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "faerie"
-version = "0.2.0"
-authors = ["m4b <m4b.github.io@gmail.com>"]
+version = "0.3.0"
+authors = ["m4b <m4b.github.io@gmail.com>", "Dan Gohman <sunfish@mozilla.com>", "Pat Hickey <pat@moreproductive.org>"]
 readme = "README.md"
 keywords = ["elf", "mach-o", "binary", "object", "compiler"]
 repository = "https://github.com/m4b/faerie"

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -181,13 +181,15 @@ impl InternalDecl {
 }
 
 /// A binding of a raw `name` to its declaration, `decl`
-pub(crate) struct Binding<'a> {
+#[derive(Debug)]
+pub struct Binding<'a> {
     pub name: &'a str,
     pub decl: &'a Decl,
 }
 
 /// A relocation binding one declaration to another
-pub(crate) struct LinkAndDecl<'a> {
+#[derive(Debug)]
+pub struct LinkAndDecl<'a> {
     pub from: Binding<'a>,
     pub to: Binding<'a>,
     pub at: usize,

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -3,7 +3,7 @@
 use goblin;
 use failure::Error;
 use {artifact, Artifact, Decl, Object, Target, Ctx, ImportKind};
-pub use artifact::LinkAndDecl;
+use artifact::LinkAndDecl;
 
 use std::collections::{HashMap, hash_map};
 use std::fmt;


### PR DESCRIPTION
Previously, a relocation in a data section would use a PC or PLT relative relocation. This meant you couldn't put a function pointer into a data section without using a `RelocOverride`, which we are trying to avoid depending on in `cretonne-faerie`.

This patch lets Elf::link examine the declaration of the `from` field of a relocation, and use a pointer-sized relocation when it is from a data section.

Relocations originating in a FunctionImport, DataImport, or CString will panic. I don't think it makes sense to put in a relocation for any of those types, however, I am open to correction.

Does this break any existing users of the library? I am only aware of my own code (which used a RelocOverride to rectify this problem) and `cretonne-faerie`. Since we are pre 1.0 I think its OK to break existing users in order to get a more sensible output here, but I'd like to hear from anyone who is depending on this.