### PR TITLE
Port faerie to the targeting crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ structopt = "0.2.3"
 structopt-derive = "0.2.3"
 string-interner = "0.6.3"
 failure = "0.1.1"
-targeting = { git = "https://github.com/cretonne/targeting" }
+target-lexicon = "0.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ structopt = "0.2.3"
 structopt-derive = "0.2.3"
 string-interner = "0.6.3"
 failure = "0.1.1"
+targeting = { git = "https://github.com/cretonne/targeting" }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Emit some object files, at your leisure:
 ```rust
 let name = "test.o";
 let file = File::create(Path::new(name))?;
-let mut obj = ArtifactBuilder::new(Target::X86_64)
+let mut obj = ArtifactBuilder::new(triple!("x86_64-unknown-unknown-unknown-elf"))
     .name(name)
     .finish();
 
@@ -74,8 +74,8 @@ obj.link(Link { from: "main", to: "printf", at: 29 })?;
 obj.link(Link { from: "main", to: "deadbeef", at: 10 })?;
 obj.link(Link { from: "deadbeef", to: "DEADBEEF", at: 7 })?;
 
-// Finally, we write which object file we desire
-obj.write::<Elf>(file)?;
+// Finally, we write the object file
+obj.write(file)?;
 ```
 
 Will emit an object file like this:

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -3,7 +3,7 @@
 use string_interner::DefaultStringInterner;
 use indexmap::IndexMap;
 use failure::Error;
-use targeting::{Triple, BinaryFormat};
+use target_lexicon::{Triple, BinaryFormat};
 
 use std::io::Write;
 use std::fs::File;

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -4,11 +4,11 @@ extern crate structopt;
 #[macro_use]
 extern crate structopt_derive;
 extern crate failure;
-extern crate targeting;
+extern crate target_lexicon;
 
 use structopt::StructOpt;
 use failure::Error;
-use targeting::{Architecture, Vendor, OperatingSystem, Environment, BinaryFormat, Triple};
+use target_lexicon::{Architecture, Vendor, OperatingSystem, Environment, BinaryFormat, Triple};
 
 use faerie::{Link, ArtifactBuilder, Decl};
 use std::path::Path;

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -4,11 +4,13 @@ extern crate structopt;
 #[macro_use]
 extern crate structopt_derive;
 extern crate failure;
+extern crate targeting;
 
 use structopt::StructOpt;
 use failure::Error;
+use targeting::{Architecture, Vendor, OperatingSystem, Environment, BinaryFormat, Triple};
 
-use faerie::{Link, Elf, Mach, Target, ArtifactBuilder, Decl};
+use faerie::{Link, ArtifactBuilder, Decl};
 use std::path::Path;
 use std::fs::File;
 use std::env;
@@ -51,7 +53,18 @@ pub struct Args {
 
 fn run (args: Args) -> Result<(), Error> {
     let file = File::create(Path::new(&args.filename))?;
-    let mut obj = ArtifactBuilder::new(Target::X86_64)
+    let target = Triple {
+        architecture: Architecture::X86_64,
+        vendor: Vendor::Unknown,
+        operating_system: OperatingSystem::Unknown,
+        environment: Environment::Unknown,
+        binary_format: if args.mach {
+            BinaryFormat::Macho
+        } else {
+            BinaryFormat::Elf
+        },
+    };
+    let mut obj = ArtifactBuilder::new(target)
         .name(args.filename.clone())
         .library(args.library)
         .finish();
@@ -121,13 +134,8 @@ fn run (args: Args) -> Result<(), Error> {
     obj.link(Link { from: "main", to: "deadbeef", at: 10 })?;
     obj.link(Link { from: "deadbeef", to: "DEADBEEF", at: 7 })?;
 
-    // Finally, we write which object file we desire
-    if args.mach {
-        obj.write::<Mach>(file)?;
-    } else {
-        obj.write::<Elf>(file)?;
-        println!("res: {:#?}", obj);
-    }
+    // Finally, we the object file
+    obj.write(file)?;
     if let Some(output) = args.link {
         link(&args.filename, &output, &args.linkline)?;
     }
@@ -136,7 +144,18 @@ fn run (args: Args) -> Result<(), Error> {
 
 fn deadbeef (args: Args) -> Result<(), Error> {
     let file = File::create(Path::new(&args.filename))?;
-    let mut obj = ArtifactBuilder::new(Target::X86_64)
+    let target = Triple {
+        architecture: Architecture::X86_64,
+        vendor: Vendor::Unknown,
+        operating_system: OperatingSystem::Unknown,
+        environment: Environment::Unknown,
+        binary_format: if args.mach {
+            BinaryFormat::Macho
+        } else {
+            BinaryFormat::Elf
+        },
+    };
+    let mut obj = ArtifactBuilder::new(target)
         .name(args.filename.clone())
         .library(args.library)
         .finish();
@@ -146,12 +165,7 @@ fn deadbeef (args: Args) -> Result<(), Error> {
     // ld.gold: warning: deadbeef.o: last entry in mergeable string section '.data.DEADBEEF' not null terminated
     obj.declare("DEADBEEF", Decl::Data { global: true, writeable: false })?;
     obj.define("DEADBEEF", [0xef, 0xbe, 0xad, 0xde].to_vec())?;
-    if args.mach {
-        obj.write::<Mach>(file)?;
-    } else {
-        obj.write::<Elf>(file)?;
-        println!("res: {:#?}", obj);
-    }
+    obj.write(file)?;
     if let Some(output) = args.link {
         link(&args.filename, &output, &args.linkline)?;
     }

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -13,7 +13,7 @@ use std::io::SeekFrom::*;
 use scroll::IOwrite;
 use string_interner::DefaultStringInterner;
 use indexmap::IndexMap;
-use targeting::Architecture;
+use target_lexicon::Architecture;
 
 use goblin::elf::header::{self, Header};
 use goblin::elf::section_header::{SectionHeader};
@@ -31,7 +31,7 @@ struct MachineTag(u16);
 
 impl From<Architecture> for MachineTag {
     fn from(architecture: Architecture) -> MachineTag {
-        use targeting::Architecture::*;
+        use target_lexicon::Architecture::*;
         use goblin::elf::header::*;
         MachineTag(match architecture {
             X86_64 => EM_X86_64,

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -2,8 +2,9 @@
 
 use goblin;
 use failure::Error;
-use {artifact, Artifact, Decl, Object, Target, Ctx, ImportKind};
+use {artifact, Artifact, Decl, Ctx, ImportKind};
 use artifact::LinkAndDecl;
+use target::make_ctx;
 
 use std::collections::{HashMap, hash_map};
 use std::fmt;
@@ -12,6 +13,7 @@ use std::io::SeekFrom::*;
 use scroll::IOwrite;
 use string_interner::DefaultStringInterner;
 use indexmap::IndexMap;
+use targeting::Architecture;
 
 use goblin::elf::header::{self, Header};
 use goblin::elf::section_header::{SectionHeader};
@@ -27,22 +29,47 @@ type Section = SectionHeader;
 
 struct MachineTag(u16);
 
-impl From<Target> for MachineTag {
-    fn from(target: Target) -> MachineTag {
-        use self::Target::*;
-        use goblin::elf::header::{EM_NONE, EM_386, EM_X86_64, EM_ARM, EM_AARCH64};
-        MachineTag(match target {
+impl From<Architecture> for MachineTag {
+    fn from(architecture: Architecture) -> MachineTag {
+        use targeting::Architecture::*;
+        use goblin::elf::header::*;
+        MachineTag(match architecture {
             X86_64 => EM_X86_64,
-            X86 => EM_386,
-            ARM64 => EM_AARCH64,
-            ARMv7 => EM_ARM,
-            Unknown => EM_NONE
+            I386 |
+            I586 |
+            I686 => EM_386,
+            Aarch64 => EM_AARCH64,
+            Arm |
+            Armv4t |
+            Armv5te |
+            Armv7 |
+            Armv7s |
+            Thumbv6m |
+            Thumbv7em |
+            Thumbv7m => EM_ARM,
+            Mips |
+            Mipsel |
+            Mips64 |
+            Mips64el => EM_MIPS,
+            Powerpc => EM_PPC,
+            Powerpc64 |
+            Powerpc64le => EM_PPC64,
+            Riscv32 |
+            Riscv64 => EM_RISCV,
+            S390x => EM_S390,
+            Sparc => EM_SPARC,
+            Sparc64 |
+            Sparcv9 => EM_SPARCV9,
+            Msp430 => EM_MSP430,
+            Unknown => EM_NONE,
+            Asmjs => panic!("asm.js does not exist in ELF"),
+            Wasm32 => panic!("wasm32 does not exist in ELF"),
         })
     }
 }
 
 /// The kind of symbol this is; used in [SymbolBuilder](struct.SymbolBuilder.html)
-pub enum SymbolType {
+enum SymbolType {
     /// A function
     Function,
     /// A data object
@@ -58,7 +85,7 @@ pub enum SymbolType {
 }
 
 /// A builder for creating a 32/64 bit ELF symbol
-pub struct SymbolBuilder {
+struct SymbolBuilder {
     name_offset: usize,
     global: bool,
     size: u64,
@@ -136,7 +163,7 @@ impl SymbolBuilder {
 }
 
 /// The kind of section this can be; used in [SectionBuilder](struct.SectionBuilder.html)
-pub enum SectionType {
+enum SectionType {
     Bits,
     Data,
     String,
@@ -147,7 +174,7 @@ pub enum SectionType {
 }
 
 /// A builder for creating a 32/64 bit section
-pub struct SectionBuilder {
+struct SectionBuilder {
     typ: SectionType,
     exec: bool,
     write: bool,
@@ -243,7 +270,7 @@ impl SectionBuilder {
 
 // r_offset: 17 r_typ: 4 r_sym: 12 r_addend: fffffffffffffffc rela: true,
 /// A builder for constructing a cross platform relocation
-pub struct RelocationBuilder {
+struct RelocationBuilder {
     rel: bool,
     addend: isize,
     sym_idx: usize,
@@ -293,7 +320,7 @@ impl RelocationBuilder {
 
 //#[derive(Debug)]
 /// An intermediate ELF object file container
-pub struct Elf<'a> {
+struct Elf<'a> {
     name: &'a str,
     code: IndexMap<StringIndex, &'a [u8]>,
     relocations: IndexMap<StringIndex, (Section, Vec<Relocation>)>,
@@ -308,7 +335,7 @@ pub struct Elf<'a> {
     sizeof_bits: Offset,
     nsections: u16,
     ctx: Ctx,
-    target: Target,
+    architecture: Architecture,
     nlocals: usize,
 }
 
@@ -334,7 +361,7 @@ const SYMTAB_LINK: u16 = 2;
 
 impl<'a> Elf<'a> {
     pub fn new(artifact: &'a Artifact) -> Self {
-        let ctx = Ctx::from(artifact.target.clone());
+        let ctx = make_ctx(&artifact.target);
         let mut offsets = HashMap::new();
         let mut strings = DefaultStringInterner::default();
         let mut special_symbols = Vec::new();
@@ -377,7 +404,7 @@ impl<'a> Elf<'a> {
             sizeof_strtab,
             sizeof_bits,
             ctx,
-            target: artifact.target.clone(),
+            architecture: artifact.target.architecture,
             nlocals: 0,
         }
     }
@@ -557,7 +584,7 @@ impl<'a> Elf<'a> {
         // Header
         /////////////////////////////////////
         let mut header = Header::new(self.ctx);
-        let machine: MachineTag = self.target.clone().into();
+        let machine: MachineTag = self.architecture.into();
         header.e_machine = machine.0;
         header.e_type = header::ET_REL;
         header.e_shoff = sh_offset;
@@ -687,24 +714,22 @@ impl<'a> Elf<'a> {
     }
 }
 
-impl<'a> Object for Elf<'a> {
-    fn to_bytes(artifact: &Artifact) -> Result<Vec<u8>, Error> {
-        // TODO: make new fully construct the elf object, e.g., the definitions, imports, and links don't take self
-        // this means that a call to new has a fully constructed object ready to marshal into bytes, similar to the mach backend
-        let mut elf = Elf::new(&artifact);
-        for def in artifact.definitions() {
-            debug!("Def: {:?}", def);
-            elf.add_definition(def.name, def.data, def.prop);
-        }
-        for (ref import, ref kind) in artifact.imports() {
-            debug!("Import: {:?} -> {:?}", import, kind);
-            elf.import(import.to_string(), kind);
-        }
-        for link in artifact.links() {
-            elf.link(&link);
-        }
-        let mut buffer = Cursor::new(Vec::new());
-        elf.write(&mut buffer)?;
-        Ok(buffer.into_inner())
+pub fn to_bytes(artifact: &Artifact) -> Result<Vec<u8>, Error> {
+    // TODO: make new fully construct the elf object, e.g., the definitions, imports, and links don't take self
+    // this means that a call to new has a fully constructed object ready to marshal into bytes, similar to the mach backend
+    let mut elf = Elf::new(&artifact);
+    for def in artifact.definitions() {
+        debug!("Def: {:?}", def);
+        elf.add_definition(def.name, def.data, def.prop);
     }
+    for (ref import, ref kind) in artifact.imports() {
+        debug!("Import: {:?} -> {:?}", import, kind);
+        elf.import(import.to_string(), kind);
+    }
+    for link in artifact.links() {
+        elf.link(&link);
+    }
+    let mut buffer = Cursor::new(Vec::new());
+    elf.write(&mut buffer)?;
+    Ok(buffer.into_inner())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,19 +6,15 @@ extern crate string_interner;
 extern crate log;
 #[macro_use]
 extern crate failure;
+extern crate targeting;
 
 use goblin::container;
 
 type Ctx = container::Ctx;
 
 mod target;
-pub use target::Target;
-
-pub mod elf;
-pub use elf::Elf;
-
-pub mod mach;
-pub use mach::Mach;
+mod elf;
+mod mach;
 
 pub mod artifact;
-pub use artifact::{Object, Artifact, ArtifactBuilder, Link, ImportKind, Decl, RelocOverride};
+pub use artifact::{Artifact, ArtifactBuilder, Link, ImportKind, Decl, RelocOverride};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ extern crate string_interner;
 extern crate log;
 #[macro_use]
 extern crate failure;
-extern crate targeting;
+extern crate target_lexicon;
 
 use goblin::container;
 

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -12,7 +12,7 @@ use std::io::{Seek, Cursor, BufWriter, Write};
 use std::io::SeekFrom::*;
 use scroll::{Pwrite, IOwrite};
 use scroll::ctx::SizeWith;
-use targeting::Architecture;
+use target_lexicon::Architecture;
 
 use goblin::mach::cputype;
 use goblin::mach::segment::{Section, Segment};
@@ -25,7 +25,7 @@ struct CpuType(cputype::CpuType);
 
 impl From<Architecture> for CpuType {
     fn from(architecture: Architecture) -> CpuType {
-        use targeting::Architecture::*;
+        use target_lexicon::Architecture::*;
         use mach::cputype::*;
         CpuType(match architecture {
             X86_64 => CPU_TYPE_X86_64,

--- a/src/target.rs
+++ b/src/target.rs
@@ -2,7 +2,7 @@
 
 use container;
 use Ctx;
-use targeting::{Triple, PointerWidth, Endianness};
+use target_lexicon::{Triple, PointerWidth, Endianness};
 
 pub fn make_ctx(target: &Triple) -> Ctx {
     let container_size = match target.pointer_width() {

--- a/src/target.rs
+++ b/src/target.rs
@@ -2,26 +2,19 @@
 
 use container;
 use Ctx;
+use targeting::{Triple, PointerWidth, Endianness};
 
-/// A machine architecture target
-#[derive(Debug, Copy, Clone)]
-pub enum Target {
-    X86_64,
-    X86,
-    ARM64,
-    ARMv7,
-    Unknown,
-}
-
-impl From<Target> for Ctx {
-    fn from(target: Target) -> Self {
-        use self::Target::*;
-        match target {
-            X86_64 => Ctx::new(container::Container::Big,   container::Endian::Little),
-            X86 => Ctx::new(container::Container::Little,   container::Endian::Little),
-            ARM64 => Ctx::new(container::Container::Big,    container::Endian::Little),
-            ARMv7 => Ctx::new(container::Container::Little, container::Endian::Little),
-            Unknown => Ctx::default(),
-        }
-    }
+pub fn make_ctx(target: &Triple) -> Ctx {
+    let container_size = match target.pointer_width() {
+        Err(()) |
+        Ok(PointerWidth::U16) => return Ctx::default(),
+        Ok(PointerWidth::U32) => container::Container::Little,
+        Ok(PointerWidth::U64) => container::Container::Big,
+    };
+    let endianness = match target.endianness() {
+        Err(()) => return Ctx::default(),
+        Ok(Endianness::Little) => container::Endian::Little,
+        Ok(Endianness::Big) => container::Endian::Big,
+    };
+    Ctx::new(container_size, endianness)
 }

--- a/tests/artifact.rs
+++ b/tests/artifact.rs
@@ -1,11 +1,14 @@
 extern crate faerie;
+#[macro_use]
+extern crate targeting;
 
 use faerie::*;
+use std::str::FromStr;
 
 #[test]
 fn duplicate_declarations_are_ok() {
 
-    let mut obj = Artifact::new(Target::X86_64, "t.o".into());
+    let mut obj = Artifact::new(triple!("x86_64"), "t.o".into());
 
     obj.declare("str.0", faerie::Decl::DataImport {}).expect(
         "initial declaration",
@@ -19,72 +22,85 @@ fn duplicate_declarations_are_ok() {
         },
     ).expect("declare should be compatible");
 
-    obj.define("str.0", b"hello world\0".to_vec())
-       .expect("define");
+    obj.define("str.0", b"hello world\0".to_vec()).expect(
+        "define",
+    );
 
-    let mut obj = Artifact::new(Target::X86_64, "t.o".into());
-    obj.declarations(vec![
-        ("str.0", faerie::Decl::DataImport),
-        ("str.0", faerie::Decl::Data {
-            global: true,
-            writeable: false
-            }),
-        ("str.0", faerie::Decl::DataImport),
-        ("str.0", faerie::Decl::DataImport),
-        ("str.0", faerie::Decl::Data {
-            global: true,
-            writeable: false
+    let mut obj = Artifact::new(triple!("x86_64"), "t.o".into());
+    obj.declarations(
+        vec![
+            ("str.0", faerie::Decl::DataImport),
+            (
+                "str.0",
+                faerie::Decl::Data {
+                    global: true,
+                    writeable: false,
+                }
+            ),
+            ("str.0", faerie::Decl::DataImport),
+            ("str.0", faerie::Decl::DataImport),
+            (
+                "str.0",
+                faerie::Decl::Data {
+                    global: true,
+                    writeable: false,
+                }
+            ),
 
-        }),
-
-        ("f", faerie::Decl::FunctionImport),
-        ("f", faerie::Decl::Function { global: true }),
-        ("f", faerie::Decl::FunctionImport),
-        ("f", faerie::Decl::FunctionImport),
-        ("f", faerie::Decl::Function { global: true }),
-    ].into_iter()
+            ("f", faerie::Decl::FunctionImport),
+            ("f", faerie::Decl::Function { global: true }),
+            ("f", faerie::Decl::FunctionImport),
+            ("f", faerie::Decl::FunctionImport),
+            ("f", faerie::Decl::Function { global: true }),
+        ].into_iter(),
     ).expect("multiple declarations are ok");
 }
 
 #[test]
 fn multiple_different_declarations_are_not_ok() {
 
-    let mut obj = Artifact::new(Target::X86_64, "t.o".into());
+    let mut obj = Artifact::new(triple!("x86_64"), "t.o".into());
 
     obj.declare("f", faerie::Decl::FunctionImport {}).expect(
         "initial declaration",
     );
 
-    assert!(obj.declare(
-        "f",
-        faerie::Decl::Data {
-            global: false,
-            writeable: false,
-        },
-    ).is_err());
+    assert!(
+        obj.declare(
+            "f",
+            faerie::Decl::Data {
+                global: false,
+                writeable: false,
+            },
+        ).is_err()
+    );
 }
 
 #[test]
 fn multiple_different_conflicting_declarations_are_not_ok_and_do_not_overwrite() {
-    let mut obj = Artifact::new(Target::X86_64, "t.o".into());
-    assert!(obj.declarations(vec![
-        ("f", faerie::Decl::FunctionImport),
-        ("f", faerie::Decl::Function { global: true }),
-        ("f", faerie::Decl::FunctionImport),
-        ("f", faerie::Decl::FunctionImport),
-        ("f", faerie::Decl::Function { global: false }),
-    ].into_iter()
-    ).is_err()); // multiple conflicting declarations are not ok
+    let mut obj = Artifact::new(triple!("x86_64"), "t.o".into());
+    assert!(
+        obj.declarations(
+            vec![
+                ("f", faerie::Decl::FunctionImport),
+                ("f", faerie::Decl::Function { global: true }),
+                ("f", faerie::Decl::FunctionImport),
+                ("f", faerie::Decl::FunctionImport),
+                ("f", faerie::Decl::Function { global: false }),
+            ].into_iter(),
+        ).is_err()
+    ); // multiple conflicting declarations are not ok
 }
 
 #[test]
 fn import_declarations_fill_imports_correctly() {
-    let mut obj = Artifact::new(Target::X86_64, "t.o".into());
-    obj.declarations(vec![
-        ("f", faerie::Decl::FunctionImport),
-        ("f", faerie::Decl::FunctionImport),
-        ("d", faerie::Decl::DataImport),
-    ].into_iter()
+    let mut obj = Artifact::new(triple!("x86_64"), "t.o".into());
+    obj.declarations(
+        vec![
+            ("f", faerie::Decl::FunctionImport),
+            ("f", faerie::Decl::FunctionImport),
+            ("d", faerie::Decl::DataImport),
+        ].into_iter(),
     ).expect("can declare");
     let imports = obj.imports().collect::<Vec<_>>();
     assert_eq!(imports.len(), 2);
@@ -92,14 +108,15 @@ fn import_declarations_fill_imports_correctly() {
 
 #[test]
 fn import_declarations_work_with_redeclarations() {
-    let mut obj = Artifact::new(Target::X86_64, "t.o".into());
-    obj.declarations(vec![
-        ("f", faerie::Decl::FunctionImport),
-        ("d", faerie::Decl::DataImport),
-        ("d", faerie::Decl::DataImport),
-        ("f", faerie::Decl::Function { global: true }),
-        ("f", faerie::Decl::FunctionImport),
-    ].into_iter()
+    let mut obj = Artifact::new(triple!("x86_64"), "t.o".into());
+    obj.declarations(
+        vec![
+            ("f", faerie::Decl::FunctionImport),
+            ("d", faerie::Decl::DataImport),
+            ("d", faerie::Decl::DataImport),
+            ("f", faerie::Decl::Function { global: true }),
+            ("f", faerie::Decl::FunctionImport),
+        ].into_iter(),
     ).expect("can declare");
     let imports = obj.imports().collect::<Vec<_>>();
     assert_eq!(imports.len(), 1);
@@ -107,19 +124,22 @@ fn import_declarations_work_with_redeclarations() {
 
 #[test]
 fn import_helper_adds_declaration_only_once() {
-    let mut obj = Artifact::new(Target::X86_64, "t.o".into());
-    obj.import("f", faerie::ImportKind::Function).expect("can import");
+    let mut obj = Artifact::new(triple!("x86_64"), "t.o".into());
+    obj.import("f", faerie::ImportKind::Function).expect(
+        "can import",
+    );
     let imports = obj.imports().collect::<Vec<_>>();
     assert_eq!(imports.len(), 1);
 }
 
 #[test]
 fn reject_duplicate_definitions() {
-    let mut obj = Artifact::new(Target::X86_64, "t.o".into());
-    obj.declarations(vec![
-        ("f", faerie::Decl::Function { global: true }),
-        ("g", faerie::Decl::Function { global: false }),
-    ].into_iter()
+    let mut obj = Artifact::new(triple!("x86_64"), "t.o".into());
+    obj.declarations(
+        vec![
+            ("f", faerie::Decl::Function { global: true }),
+            ("g", faerie::Decl::Function { global: false }),
+        ].into_iter(),
     ).expect("can declare");
 
     obj.define("g", vec![1, 2, 3, 4]).expect("can define");
@@ -134,18 +154,20 @@ fn reject_duplicate_definitions() {
 
 #[test]
 fn undefined_symbols() {
-    let mut obj = Artifact::new(Target::X86_64, "t.o".into());
-    obj.declarations(vec![
-        ("f", faerie::Decl::Function { global: true }),
-        ("g", faerie::Decl::Function { global: false }),
-    ].into_iter()
+    let mut obj = Artifact::new(triple!("x86_64"), "t.o".into());
+    obj.declarations(
+        vec![
+            ("f", faerie::Decl::Function { global: true }),
+            ("g", faerie::Decl::Function { global: false }),
+        ].into_iter(),
     ).expect("can declare");
-    assert_eq!(obj.undefined_symbols(),
-        vec![String::from("f"), String::from("g")]);
+    assert_eq!(
+        obj.undefined_symbols(),
+        vec![String::from("f"), String::from("g")]
+    );
 
     obj.define("g", vec![1, 2, 3, 4]).expect("can define");
-    assert_eq!(obj.undefined_symbols(),
-        vec![String::from("f")]);
+    assert_eq!(obj.undefined_symbols(), vec![String::from("f")]);
 
     obj.define("f", vec![4, 3, 2, 1]).expect("can define");
     assert!(obj.undefined_symbols().is_empty());

--- a/tests/artifact.rs
+++ b/tests/artifact.rs
@@ -1,6 +1,6 @@
 extern crate faerie;
 #[macro_use]
-extern crate targeting;
+extern crate target_lexicon;
 #[cfg(test)]
 extern crate goblin;
 
@@ -177,7 +177,7 @@ fn undefined_symbols() {
 
 #[test]
 fn vary_output_formats() {
-    use targeting::BinaryFormat;
+    use target_lexicon::BinaryFormat;
     use goblin::Object;
 
     let obj = Artifact::new(triple!("x86_64"), "t.o".into());

--- a/tests/elf.rs
+++ b/tests/elf.rs
@@ -2,7 +2,7 @@ extern crate faerie;
 extern crate scroll;
 extern crate goblin;
 #[macro_use]
-extern crate targeting;
+extern crate target_lexicon;
 
 use std::str::FromStr;
 

--- a/tests/elf.rs
+++ b/tests/elf.rs
@@ -1,19 +1,23 @@
 extern crate faerie;
 extern crate scroll;
 extern crate goblin;
+#[macro_use]
+extern crate targeting;
 
-use faerie::{Artifact, Decl, Target, Link};
+use std::str::FromStr;
+
+use faerie::{Artifact, Decl, Link};
 use goblin::elf::*;
 
 #[test]
 // This test is for a known bug (issue #31).
 fn file_name_is_same_as_symbol_name_issue_31() {
     const NAME: &str = "a";
-    let mut obj = Artifact::new(Target::X86_64, "a".into());
+    let mut obj = Artifact::new(triple!("x86_64-unknown-unknown-unknown-elf"), "a".into());
     obj.declare(NAME, Decl::Function { global: true }).expect("can declare");
     obj.define(NAME, vec![1, 2, 3, 4]).expect("can define");
     println!("\n{:#?}", obj);
-    let bytes = obj.emit::<faerie::Elf>().expect("can emit elf file");
+    let bytes = obj.emit().expect("can emit elf file");
     let bytes = bytes.as_slice();
     println!("{:?}", bytes);
 
@@ -45,7 +49,7 @@ fn file_name_is_same_as_symbol_name_issue_31() {
 // Regression test for issue 30: previously, if a non-import symbol was declared but not defined,
 // the elf emit function would panic
 fn link_symbol_pair_panic_issue_30() {
-    let mut obj = Artifact::new(Target::X86_64, "t.o".into());
+    let mut obj = Artifact::new(triple!("x86_64-unknown-unknown-unknown-elf"), "t.o".into());
 
     obj.declare("a", Decl::Function { global: true }).expect("can declare a");
     obj.declare_with("b", Decl::Function { global: true }, vec![1, 2, 3, 4]).expect("can declare and define b");
@@ -61,5 +65,5 @@ fn link_symbol_pair_panic_issue_30() {
 
     // The `emit` method will check that there are undefined symbols
     // and return an error describing them:
-    assert!(obj.emit::<faerie::Elf>().is_err());
+    assert!(obj.emit().is_err());
 }


### PR DESCRIPTION
`targeting` is a new crate that provides a vocabulary for describing targets,
including their architecture and binary file format. The patch here replaces
faerie's `Target` enum and `Object` trait with targeting's `Triple` struct.

This has the following advantages:
 - Artifact::emit and Artifact::write no longer have a type parameter, so
   users of faeiry don't have to add extra abstraction in order to support
   multiple formats dynamically (as Cretonne currently does [here]).

 - targeting is rich enough that compilers can use it directly. It supports
   the same set of target names that rustc uses. This eliminates the need to
   translate between different target enums when using faerie.

[here]: https://github.com/cretonne/cretonne/blob/master/lib/faerie/src/container.rs#L7

One downside is that this ends up requring the binary format to be specified
in the `Artifact` constructor, rather than being a parameter to `emit` or
`write` at the end. However, if this turns out to be important in practice,
it wouldn't be difficult to add a way to mutate an `Artifact`'s target.

This PR currently uses a git url dependency. I'm planning to publish a crates.io
package, but I'm hoping to get some feedback, including potentially on the name of
the package :-). I'm not settled on `targeting` yet.