### PR TITLE
Rename "writeable" to "writable".

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faerie"
-version = "0.4.4"
+version = "0.5.0"
 authors = ["m4b <m4b.github.io@gmail.com>", "Dan Gohman <sunfish@mozilla.com>", "Pat Hickey <pat@moreproductive.org>"]
 readme = "README.md"
 keywords = ["elf", "mach-o", "binary", "object", "compiler"]

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -62,7 +62,7 @@ pub enum ArtifactError {
 pub struct Prop {
     pub global: bool,
     pub function: bool,
-    pub writeable: bool,
+    pub writable: bool,
     pub cstring: bool,
 }
 
@@ -85,7 +85,7 @@ pub enum Decl {
     /// A function defined in this artifact
     Function { global: bool },
     /// A data object defined in this artifact
-    Data { global: bool, writeable: bool },
+    Data { global: bool, writable: bool },
     /// A null-terminated string object defined in this artifact
     CString { global: bool }
 }
@@ -415,9 +415,9 @@ impl Artifact {
                     return Err(ArtifactError::DuplicateDefinition(name.as_ref().to_string()));
                 }
                 let prop = match stype.decl {
-                    Decl::CString { global } => Prop { global, function: false, writeable: false, cstring: true },
-                    Decl::Data { global, writeable } => Prop { global, function: false, writeable, cstring: false },
-                    Decl::Function { global } => Prop { global, function: true, writeable: false, cstring: false},
+                    Decl::CString { global } => Prop { global, function: false, writable: false, cstring: true },
+                    Decl::Data { global, writable } => Prop { global, function: false, writable, cstring: false },
+                    Decl::Function { global } => Prop { global, function: true, writable: false, cstring: false},
                     _ if stype.decl.is_import() => return Err(ArtifactError::ImportDefined(name.as_ref().to_string()).into()),
                     _ => unimplemented!("New Decl variant added but not covered in define method"),
                 };

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -163,7 +163,7 @@ fn deadbeef (args: Args) -> Result<(), Error> {
     // FIXME: need to state this isn't a string, but some linkers don't seem to care \o/
     // gold complains though:
     // ld.gold: warning: deadbeef.o: last entry in mergeable string section '.data.DEADBEEF' not null terminated
-    obj.declare("DEADBEEF", Decl::Data { global: true, writeable: false })?;
+    obj.declare("DEADBEEF", Decl::Data { global: true, writable: false })?;
     obj.define("DEADBEEF", [0xef, 0xbe, 0xad, 0xde].to_vec())?;
     obj.write(file)?;
     if let Some(output) = args.link {

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -203,9 +203,9 @@ impl SectionBuilder {
     pub fn alloc(mut self) -> Self {
         self.alloc = true; self
     }
-    /// Make this section writeable
-    pub fn writeable(mut self, writeable:bool) -> Self {
-        self.write = writeable; self
+    /// Make this section writable
+    pub fn writable(mut self, writable:bool) -> Self {
+        self.write = writable; self
     }
 
     /// Set the byte offset of this section's name in the corresponding strtab
@@ -466,7 +466,7 @@ impl<'a> Elf<'a> {
             let tmp = SectionBuilder::new(size as u64)
                 .name_offset(section_offset)
                 .section_type(stype)
-                .alloc().writeable(prop.writeable);
+                .alloc().writable(prop.writable);
 
             // FIXME: I don't like this at all; can make exec() take bool but doesn't match other section properties
             if prop.function { tmp.exec().create(&self.ctx) } else { tmp.create(&self.ctx) }

--- a/tests/artifact.rs
+++ b/tests/artifact.rs
@@ -20,7 +20,7 @@ fn duplicate_declarations_are_ok() {
         "str.0",
         faerie::Decl::Data {
             global: false,
-            writeable: false,
+            writable: false,
         },
     ).expect("declare should be compatible");
 
@@ -36,7 +36,7 @@ fn duplicate_declarations_are_ok() {
                 "str.0",
                 faerie::Decl::Data {
                     global: true,
-                    writeable: false,
+                    writable: false,
                 }
             ),
             ("str.0", faerie::Decl::DataImport),
@@ -45,7 +45,7 @@ fn duplicate_declarations_are_ok() {
                 "str.0",
                 faerie::Decl::Data {
                     global: true,
-                    writeable: false,
+                    writable: false,
                 }
             ),
 
@@ -72,7 +72,7 @@ fn multiple_different_declarations_are_not_ok() {
             "f",
             faerie::Decl::Data {
                 global: false,
-                writeable: false,
+                writable: false,
             },
         ).is_err()
     );


### PR DESCRIPTION
"Writable" seems the more common English spelling.

This is mainly because cranelift code currently uses "writable" (without the "e") and faerie uses "writeable" (with the "e"), and I can cope either way, as long as they agree :-).