### PR TITLE
Fix Mach-O debug relocations

### DIFF
--- a/src/mach.rs
+++ b/src/mach.rs
@@ -686,7 +686,7 @@ fn build_relocations(segment: &mut SegmentBuilder, artifact: &Artifact, symtab: 
                         _ => error!("Import Relocation from {} to {} at {:#x} has a missing symbol. Dumping symtab {:?}", link.from.name, link.to.name, link.at, symtab)
                     }
                 }
-                return;
+                continue;
             }
         };
         match (symtab.offset(link.from.name), symtab.index(link.to.name)) {


### PR DESCRIPTION
I accidentially used `return` instead of `continue` in #56, so faerie would skip all relocations after the first debug one.