### PR TITLE
Extensible Decl interface

### DIFF
--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -11,8 +11,8 @@ use std::io::Write;
 
 use crate::{elf, mach};
 
-mod decl;
-pub use decl::*;
+pub(crate) mod decl;
+pub use decl::Decl;
 
 /// A blob of binary bytes, representing a function body, or data object
 pub type Data = Vec<u8>;

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -11,6 +11,9 @@ use std::io::Write;
 
 use crate::{elf, mach};
 
+mod decl;
+pub use decl::*;
+
 /// A blob of binary bytes, representing a function body, or data object
 pub type Data = Vec<u8>;
 
@@ -81,133 +84,6 @@ struct InternalDefinition {
 }
 // end note
 ///////////////////////////////////////////////
-
-/// The kind of declaration this is
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum Decl {
-    /// An import of a function/routine defined in a shared library
-    FunctionImport,
-    /// A GOT-based import of data defined in a shared library
-    DataImport,
-    /// A function defined in this artifact
-    Function { global: bool },
-    /// A data object defined in this artifact
-    Data { global: bool, writable: bool },
-    /// A null-terminated string object defined in this artifact
-    CString { global: bool },
-    /// A DWARF debug section defined in this artifact
-    DebugSection,
-}
-
-impl Decl {
-    /// If it is compatible, absorb the new declaration (`other`) into the old (`self`); otherwise returns an error.
-    ///
-    /// The rule here is "C-ish", but essentially:
-    ///
-    /// 1. Duplicate declarations are no-ops / ignored.
-    /// 2. **If** the previous declaration was an [FunctionImport](enum.Decl.html#variant.FunctionImport) or [DataImport](enum.Decl.html#variant.DataImport),
-    ///    **then** if the subsequent declaration is a corresponding matching [Function](enum.Decl.html#variant.Function) or [Data](enum.Decl.html#variant.Data)
-    ///    declaration, it is said to be "upgraded", and forever after is considered a declaration in need of a definition.
-    /// 3. **If** the previous declaration was a `Function` or `Data` declaration,
-    ///    **then** a subsequent corresponding `FunctionImport` or `DataImport` is a no-op.
-    /// 4. Anything else is a [IncompatibleDeclaration](enum.ArtifactError.html#variant.IncompatibleDeclaration) error!
-    // ref https://github.com/m4b/faerie/issues/24
-    // ref https://github.com/m4b/faerie/issues/18
-    pub fn absorb(&mut self, other: Self) -> Result<(), Error> {
-        // FIXME: i can't think of a way offhand to not clone here, without unusual contortions
-        match self.clone() {
-            Decl::DataImport => {
-                match other {
-                    // data imports can be upgraded to any kind of data declaration
-                    Decl::Data { .. } => {
-                        *self = other;
-                        Ok(())
-                    }
-                    Decl::DataImport => Ok(()),
-                    _ => Err(ArtifactError::IncompatibleDeclaration {
-                        old: *self,
-                        new: other,
-                    }
-                    .into()),
-                }
-            }
-            Decl::FunctionImport => {
-                match other {
-                    // function imports can be upgraded to any kind of function declaration
-                    Decl::Function { .. } => {
-                        *self = other;
-                        Ok(())
-                    }
-                    Decl::FunctionImport => Ok(()),
-                    _ => Err(ArtifactError::IncompatibleDeclaration {
-                        old: *self,
-                        new: other,
-                    }
-                    .into()),
-                }
-            }
-            // a previous data declaration can only be re-declared a data import, or it must match exactly the
-            // next declaration
-            decl @ Decl::Data { .. } => match other {
-                Decl::DataImport => Ok(()),
-                other => {
-                    if decl == other {
-                        Ok(())
-                    } else {
-                        Err(ArtifactError::IncompatibleDeclaration {
-                            old: *self,
-                            new: other,
-                        }
-                        .into())
-                    }
-                }
-            },
-            // a previous function decl can only be re-declared a function import, or it must match exactly
-            // the next declaration
-            decl @ Decl::Function { .. } => match other {
-                Decl::FunctionImport => Ok(()),
-                other => {
-                    if decl == other {
-                        Ok(())
-                    } else {
-                        Err(ArtifactError::IncompatibleDeclaration {
-                            old: *self,
-                            new: other,
-                        }
-                        .into())
-                    }
-                }
-            },
-            decl => {
-                if decl == other {
-                    Ok(())
-                } else {
-                    Err(ArtifactError::IncompatibleDeclaration {
-                        old: *self,
-                        new: other,
-                    }
-                    .into())
-                }
-            }
-        }
-    }
-    /// Is this an import (function or data) from a shared library?
-    pub fn is_import(&self) -> bool {
-        use crate::Decl::*;
-        match *self {
-            FunctionImport => true,
-            DataImport => true,
-            _ => false,
-        }
-    }
-    /// Is this a section?
-    pub fn is_section(&self) -> bool {
-        match *self {
-            Decl::DebugSection { .. } => true,
-            _ => false,
-        }
-    }
-}
 
 /// A declaration, plus a flag to track whether we have a definition for it yet
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -301,7 +301,8 @@ impl Artifact {
     }
     /// Declare a new symbolic reference, with the given `decl`.
     /// **Note**: All declarations _must_ precede their definitions.
-    pub fn declare<T: AsRef<str>>(&mut self, name: T, decl: Decl) -> Result<(), Error> {
+    pub fn declare<T: AsRef<str>, D: Into<Decl>>(&mut self, name: T, decl: D) -> Result<(), Error> {
+        let decl = decl.into();
         let decl_name = self.strings.get_or_intern(name.as_ref());
         let previous_was_import;
         let new_idecl = {

--- a/src/artifact/decl.rs
+++ b/src/artifact/decl.rs
@@ -19,6 +19,31 @@ pub enum Decl {
 }
 
 impl Decl {
+    /// An import of a function/routine defined in a shared library
+    pub fn function_import() -> FunctionImportDecl {
+        FunctionImportDecl::default()
+    }
+    /// A GOT-based import of data defined in a shared library
+    pub fn data_import() -> DataImportDecl {
+        DataImportDecl::default()
+    }
+    /// A function defined in this artifact
+    pub fn function() -> FunctionDecl {
+        FunctionDecl::default()
+    }
+    /// A data object defined in this artifact
+    pub fn data() -> DataDecl {
+        DataDecl::default()
+    }
+    /// A null-terminated string object defined in this artifact
+    pub fn cstring() -> CStringDecl {
+        CStringDecl::default()
+    }
+    /// A DWARF debug section defined in this artifact
+    pub fn debug_section() -> DebugSectionDecl {
+        DebugSectionDecl::default()
+    }
+
     /// If it is compatible, absorb the new declaration (`other`) into the old (`self`); otherwise returns an error.
     ///
     /// The rule here is "C-ish", but essentially:
@@ -125,5 +150,147 @@ impl Decl {
             Decl::DebugSection { .. } => true,
             _ => false,
         }
+    }
+}
+
+pub struct FunctionImportDecl {}
+
+impl Default for FunctionImportDecl {
+    fn default() -> Self {
+        FunctionImportDecl {}
+    }
+}
+
+impl Into<Decl> for FunctionImportDecl {
+    fn into(self) -> Decl {
+        Decl::FunctionImport
+    }
+}
+
+pub struct DataImportDecl {}
+
+impl Default for DataImportDecl {
+    fn default() -> Self {
+        DataImportDecl {}
+    }
+}
+
+impl Into<Decl> for DataImportDecl {
+    fn into(self) -> Decl {
+        Decl::DataImport
+    }
+}
+
+pub struct FunctionDecl {
+    global: bool,
+}
+
+impl Default for FunctionDecl {
+    fn default() -> Self {
+        FunctionDecl { global: false }
+    }
+}
+
+impl FunctionDecl {
+    pub fn global(mut self) -> Self {
+        self.global = true;
+        self
+    }
+    pub fn local(mut self) -> Self {
+        self.global = false;
+        self
+    }
+}
+
+impl Into<Decl> for FunctionDecl {
+    fn into(self) -> Decl {
+        Decl::Function {
+            global: self.global,
+        }
+    }
+}
+
+pub struct DataDecl {
+    global: bool,
+    writable: bool,
+}
+
+impl Default for DataDecl {
+    fn default() -> Self {
+        DataDecl {
+            global: false,
+            writable: false,
+        }
+    }
+}
+
+impl DataDecl {
+    pub fn global(mut self) -> Self {
+        self.global = true;
+        self
+    }
+    pub fn local(mut self) -> Self {
+        self.global = false;
+        self
+    }
+    pub fn writable(mut self) -> Self {
+        self.writable = true;
+        self
+    }
+    pub fn read_only(mut self) -> Self {
+        self.writable = false;
+        self
+    }
+}
+
+impl Into<Decl> for DataDecl {
+    fn into(self) -> Decl {
+        Decl::Data {
+            global: self.global,
+            writable: self.writable,
+        }
+    }
+}
+
+pub struct CStringDecl {
+    global: bool,
+}
+
+impl Default for CStringDecl {
+    fn default() -> Self {
+        CStringDecl { global: false }
+    }
+}
+
+impl CStringDecl {
+    pub fn global(mut self) -> Self {
+        self.global = true;
+        self
+    }
+    pub fn local(mut self) -> Self {
+        self.global = false;
+        self
+    }
+}
+
+impl Into<Decl> for CStringDecl {
+    fn into(self) -> Decl {
+        Decl::CString {
+            global: self.global,
+        }
+    }
+}
+
+pub struct DebugSectionDecl {}
+
+impl Default for DebugSectionDecl {
+    fn default() -> Self {
+        DebugSectionDecl {}
+    }
+}
+
+impl Into<Decl> for DebugSectionDecl {
+    fn into(self) -> Decl {
+        Decl::DebugSection
     }
 }

--- a/src/artifact/decl.rs
+++ b/src/artifact/decl.rs
@@ -1,0 +1,129 @@
+use crate::artifact::ArtifactError;
+use failure::Error;
+
+/// The kind of declaration this is
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Decl {
+    /// An import of a function/routine defined in a shared library
+    FunctionImport,
+    /// A GOT-based import of data defined in a shared library
+    DataImport,
+    /// A function defined in this artifact
+    Function { global: bool },
+    /// A data object defined in this artifact
+    Data { global: bool, writable: bool },
+    /// A null-terminated string object defined in this artifact
+    CString { global: bool },
+    /// A DWARF debug section defined in this artifact
+    DebugSection,
+}
+
+impl Decl {
+    /// If it is compatible, absorb the new declaration (`other`) into the old (`self`); otherwise returns an error.
+    ///
+    /// The rule here is "C-ish", but essentially:
+    ///
+    /// 1. Duplicate declarations are no-ops / ignored.
+    /// 2. **If** the previous declaration was an [FunctionImport](enum.Decl.html#variant.FunctionImport) or [DataImport](enum.Decl.html#variant.DataImport),
+    ///    **then** if the subsequent declaration is a corresponding matching [Function](enum.Decl.html#variant.Function) or [Data](enum.Decl.html#variant.Data)
+    ///    declaration, it is said to be "upgraded", and forever after is considered a declaration in need of a definition.
+    /// 3. **If** the previous declaration was a `Function` or `Data` declaration,
+    ///    **then** a subsequent corresponding `FunctionImport` or `DataImport` is a no-op.
+    /// 4. Anything else is a [IncompatibleDeclaration](enum.ArtifactError.html#variant.IncompatibleDeclaration) error!
+    // ref https://github.com/m4b/faerie/issues/24
+    // ref https://github.com/m4b/faerie/issues/18
+    pub fn absorb(&mut self, other: Self) -> Result<(), Error> {
+        // FIXME: i can't think of a way offhand to not clone here, without unusual contortions
+        match self.clone() {
+            Decl::DataImport => {
+                match other {
+                    // data imports can be upgraded to any kind of data declaration
+                    Decl::Data { .. } => {
+                        *self = other;
+                        Ok(())
+                    }
+                    Decl::DataImport => Ok(()),
+                    _ => Err(ArtifactError::IncompatibleDeclaration {
+                        old: *self,
+                        new: other,
+                    }
+                    .into()),
+                }
+            }
+            Decl::FunctionImport => {
+                match other {
+                    // function imports can be upgraded to any kind of function declaration
+                    Decl::Function { .. } => {
+                        *self = other;
+                        Ok(())
+                    }
+                    Decl::FunctionImport => Ok(()),
+                    _ => Err(ArtifactError::IncompatibleDeclaration {
+                        old: *self,
+                        new: other,
+                    }
+                    .into()),
+                }
+            }
+            // a previous data declaration can only be re-declared a data import, or it must match exactly the
+            // next declaration
+            decl @ Decl::Data { .. } => match other {
+                Decl::DataImport => Ok(()),
+                other => {
+                    if decl == other {
+                        Ok(())
+                    } else {
+                        Err(ArtifactError::IncompatibleDeclaration {
+                            old: *self,
+                            new: other,
+                        }
+                        .into())
+                    }
+                }
+            },
+            // a previous function decl can only be re-declared a function import, or it must match exactly
+            // the next declaration
+            decl @ Decl::Function { .. } => match other {
+                Decl::FunctionImport => Ok(()),
+                other => {
+                    if decl == other {
+                        Ok(())
+                    } else {
+                        Err(ArtifactError::IncompatibleDeclaration {
+                            old: *self,
+                            new: other,
+                        }
+                        .into())
+                    }
+                }
+            },
+            decl => {
+                if decl == other {
+                    Ok(())
+                } else {
+                    Err(ArtifactError::IncompatibleDeclaration {
+                        old: *self,
+                        new: other,
+                    }
+                    .into())
+                }
+            }
+        }
+    }
+    /// Is this an import (function or data) from a shared library?
+    pub fn is_import(&self) -> bool {
+        use Decl::*;
+        match *self {
+            FunctionImport => true,
+            DataImport => true,
+            _ => false,
+        }
+    }
+    /// Is this a section?
+    pub fn is_section(&self) -> bool {
+        match *self {
+            Decl::DebugSection { .. } => true,
+            _ => false,
+        }
+    }
+}

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -81,14 +81,14 @@ fn run (args: Args) -> Result<(), Error> {
 
     // first we declare our symbolic references;
     // it is a runtime error to define a symbol _without_ declaring it first
-    let declarations = vec![
-        ("deadbeef",   Decl::Function { global: false }),
-        ("main",       Decl::Function { global: true }),
-        ("str.1",      Decl::CString { global: false }),
-        ("DEADBEEF",   Decl::DataImport),
-        ("STATIC",     Decl::Data { global: true, writable: true }),
-        ("STATIC_REF", Decl::Data { global: true, writable: true }),
-        ("printf",     Decl::FunctionImport),
+    let declarations: Vec<(&'static str, Decl)> = vec![
+        ("deadbeef", Decl::function().into()),
+        ("main", Decl::function().global().into()),
+        ("str.1", Decl::cstring().into()),
+        ("DEADBEEF", Decl::data_import().into()),
+        ("STATIC", Decl::data().global().writable().into()),
+        ("STATIC_REF", Decl::data().global().writable().into()),
+        ("printf", Decl::function_import().into()),
     ];
     obj.declarations(declarations.into_iter())?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,4 +17,10 @@ mod mach;
 mod target;
 
 pub mod artifact;
-pub use crate::artifact::{Artifact, ArtifactBuilder, Decl, ImportKind, Link, Reloc};
+pub use crate::artifact::{
+    decl::{
+        CStringDecl, DataDecl, DataImportDecl, DebugSectionDecl, Decl, FunctionDecl,
+        FunctionImportDecl,
+    },
+    Artifact, ArtifactBuilder, ImportKind, Link, Reloc,
+};


### PR DESCRIPTION
Presently, `artifact::Decl` is exposed as a public enum. This means that each user of the library needs to know about the internals of `Decl`.

For both #60 and #61, we need to modify or extend the fields inside individual Decl variants. I also would like to add optional alignment information to declarations. To minimize the burden on library users, this PR proposes an alternative interface to constructing Decls that will allow (many kinds of) representation changes without changes to the interface. This PR is not a breaking change, but existing library users should migrate to it. The full Decl enum will remain public, and library users are welcome to continue using it, as long as they don't mind keeping up with changes.

In this PR:
* Move Decl to its own file under artifact, to minimize the noise in artifact.
* For each variant in Decl, define a struct <variant>Decl that has a `Default impl`, `pub fn(self)->Self` methods for modifying the fields (if any), and an `Into<Decl>` impl.
* `Artifact::declare` takes an `Into<Decl>`.
* Updated the binary to use the new interface

