### PR TITLE
Carry declarations through

### DIFF
--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -12,7 +12,7 @@ use std::io::Write;
 use crate::{elf, mach};
 
 pub(crate) mod decl;
-pub use decl::{DefinedDecl, Decl, ImportKind};
+pub use decl::{Decl, DefinedDecl, ImportKind};
 
 /// A blob of binary bytes, representing a function body, or data object
 pub type Data = Vec<u8>;

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -241,10 +241,10 @@ impl Artifact {
     }
     /// Declare and define a new symbolic reference with the given `decl` and given `definition`.
     /// This is sugar for `declare` and then `define`
-    pub fn declare_with<T: AsRef<str>>(
+    pub fn declare_with<T: AsRef<str>, D: Into<Decl>>(
         &mut self,
         name: T,
-        decl: Decl,
+        decl: D,
         definition: Vec<u8>,
     ) -> Result<(), Error> {
         self.declare(name.as_ref(), decl)?;

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -170,10 +170,7 @@ pub struct Artifact {
     /// Whether this is a static library or not
     pub is_library: bool,
     // will keep this for now; may be useful to pre-partition code and data vectors, not sure
-    code: Vec<(StringID, Data)>,
-    data: Vec<(StringID, Data)>,
     imports: Vec<(StringID, ImportKind)>,
-    import_links: Vec<Relocation>,
     links: Vec<Relocation>,
     declarations: IndexMap<StringID, InternalDecl>,
     local_definitions: BTreeSet<InternalDefinition>,
@@ -186,10 +183,7 @@ impl Artifact {
     /// Create a new binary Artifact, with `target` and optional `name`
     pub fn new(target: Triple, name: String) -> Self {
         Artifact {
-            code: Vec::new(),
-            data: Vec::new(),
             imports: Vec::new(),
-            import_links: Vec::new(),
             links: Vec::new(),
             name,
             target,

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -12,7 +12,7 @@ use std::io::Write;
 use crate::{elf, mach};
 
 pub(crate) mod decl;
-pub use decl::{ADecl, Decl, ImportKind};
+pub use decl::{DefinedDecl, Decl, ImportKind};
 
 /// A blob of binary bytes, representing a function body, or data object
 pub type Data = Vec<u8>;
@@ -54,7 +54,7 @@ pub enum ArtifactError {
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 struct InternalDefinition {
-    adecl: ADecl,
+    adecl: DefinedDecl,
     name: StringID,
     data: Data,
 }
@@ -101,7 +101,7 @@ pub struct LinkAndDecl<'a> {
 pub(crate) struct Definition<'a> {
     pub name: &'a str,
     pub data: &'a [u8],
-    pub adecl: &'a ADecl,
+    pub adecl: &'a DefinedDecl,
 }
 
 impl<'a> From<(&'a InternalDefinition, &'a DefaultStringInterner)> for Definition<'a> {
@@ -323,7 +323,7 @@ impl Artifact {
                     ))?;
                 }
                 let adecl = match stype.decl {
-                    Decl::Artifact(adecl) => adecl,
+                    Decl::Defined(adecl) => adecl,
                     Decl::Import(_) => {
                         Err(ArtifactError::ImportDefined(name.as_ref().to_string()).into())?
                     }

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -54,7 +54,7 @@ pub enum ArtifactError {
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 struct InternalDefinition {
-    adecl: DefinedDecl,
+    decl: DefinedDecl,
     name: StringID,
     data: Data,
 }
@@ -101,7 +101,7 @@ pub struct LinkAndDecl<'a> {
 pub(crate) struct Definition<'a> {
     pub name: &'a str,
     pub data: &'a [u8],
-    pub adecl: &'a DefinedDecl,
+    pub decl: &'a DefinedDecl,
 }
 
 impl<'a> From<(&'a InternalDefinition, &'a DefaultStringInterner)> for Definition<'a> {
@@ -111,7 +111,7 @@ impl<'a> From<(&'a InternalDefinition, &'a DefaultStringInterner)> for Definitio
                 .resolve(def.name)
                 .expect("internal definition to have name"),
             data: &def.data,
-            adecl: &def.adecl,
+            decl: &def.decl,
         }
     }
 }
@@ -322,23 +322,23 @@ impl Artifact {
                         name.as_ref().to_string(),
                     ))?;
                 }
-                let adecl = match stype.decl {
-                    Decl::Defined(adecl) => adecl,
+                let decl = match stype.decl {
+                    Decl::Defined(decl) => decl,
                     Decl::Import(_) => {
                         Err(ArtifactError::ImportDefined(name.as_ref().to_string()).into())?
                     }
                 };
-                if adecl.is_global() {
+                if decl.is_global() {
                     self.nonlocal_definitions.insert(InternalDefinition {
                         name: decl_name,
                         data,
-                        adecl,
+                        decl,
                     });
                 } else {
                     self.local_definitions.insert(InternalDefinition {
                         name: decl_name,
                         data,
-                        adecl,
+                        decl,
                     });
                 }
                 stype.define();

--- a/src/artifact/decl.rs
+++ b/src/artifact/decl.rs
@@ -4,7 +4,9 @@ use failure::Error;
 /// The kind of declaration this is
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Decl {
+    /// Declaration of an import
     Import(ImportKind),
+    /// Declaration of an item to be defined in this artifact
     Defined(DefinedDecl),
 }
 
@@ -18,6 +20,7 @@ pub enum ImportKind {
 }
 
 impl ImportKind {
+    /// Accessor for the ImportKind associated with a Decl, if there is one
     pub fn from_decl(decl: &Decl) -> Option<Self> {
         match decl {
             Decl::Import(ik) => Some(*ik),

--- a/src/artifact/decl.rs
+++ b/src/artifact/decl.rs
@@ -2,14 +2,14 @@ use crate::artifact::ArtifactError;
 use failure::Error;
 
 /// The kind of declaration this is
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Decl {
     Import(ImportKind),
     Artifact(ADecl),
 }
 
 /// The kind of import this is - either a function, or a copy relocation of data from a shared library
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ImportKind {
     /// A function
     Function,
@@ -26,7 +26,7 @@ impl ImportKind {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ADecl {
     /// A function defined in this artifact
     Function { global: bool },
@@ -36,6 +36,26 @@ pub enum ADecl {
     CString { global: bool },
     /// A DWARF debug section defined in this artifact
     DebugSection,
+}
+
+impl ADecl {
+    /// Accessor to determine whether scope is global
+    pub fn is_global(&self) -> bool {
+        match self {
+            ADecl::Function { global, .. } => *global,
+            ADecl::Data { global, .. } => *global,
+            ADecl::CString { global, .. } => *global,
+            ADecl::DebugSection { .. } => false,
+        }
+    }
+
+    /// Accessor to determine whether contents are writable
+    pub fn is_writable(&self) -> bool {
+        match self {
+            ADecl::Data { writable, .. } => *writable,
+            ADecl::Function { .. } | ADecl::CString { .. } | ADecl::DebugSection { .. } => false,
+        }
+    }
 }
 
 impl Decl {

--- a/src/artifact/decl.rs
+++ b/src/artifact/decl.rs
@@ -39,6 +39,38 @@ pub enum DefinedDecl {
 }
 
 impl DefinedDecl {
+    /// Accessor to determine whether variant is Function
+    pub fn is_function(&self) -> bool {
+        match self {
+            DefinedDecl::Function { .. } => true,
+            _ => false,
+        }
+    }
+
+    /// Accessor to determine whether variant is Data
+    pub fn is_data(&self) -> bool {
+        match self {
+            DefinedDecl::Data { .. } => true,
+            _ => false,
+        }
+    }
+
+    /// Accessor to determine whether variant is CString
+    pub fn is_cstring(&self) -> bool {
+        match self {
+            DefinedDecl::CString { .. } => true,
+            _ => false,
+        }
+    }
+
+    /// Accessor to determine whether variant is DebugSection
+    pub fn is_debug_section(&self) -> bool {
+        match self {
+            DefinedDecl::DebugSection { .. } => true,
+            _ => false,
+        }
+    }
+
     /// Accessor to determine whether scope is global
     pub fn is_global(&self) -> bool {
         match self {
@@ -53,7 +85,9 @@ impl DefinedDecl {
     pub fn is_writable(&self) -> bool {
         match self {
             DefinedDecl::Data { writable, .. } => *writable,
-            DefinedDecl::Function { .. } | DefinedDecl::CString { .. } | DefinedDecl::DebugSection { .. } => false,
+            DefinedDecl::Function { .. }
+            | DefinedDecl::CString { .. }
+            | DefinedDecl::DebugSection { .. } => false,
         }
     }
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -204,14 +204,14 @@ fn deadbeef (args: Args) -> Result<(), Error> {
     // FIXME: need to state this isn't a string, but some linkers don't seem to care \o/
     // gold complains though:
     // ld.gold: warning: deadbeef.o: last entry in mergeable string section '.data.DEADBEEF' not null terminated
-    obj.declare("DEADBEEF", Decl::Data { global: true, writable: false })?;
+    obj.declare("DEADBEEF", Decl::data().global().read_only())?;
     obj.define("DEADBEEF", [0xef, 0xbe, 0xad, 0xde].to_vec())?;
 
     if args.dwarf {
         // DWARF sections
-        obj.declare(".debug_abbrev", Decl::DebugSection)?;
-        obj.declare(".debug_info", Decl::DebugSection)?;
-        obj.declare(".debug_str", Decl::DebugSection)?;
+        obj.declare(".debug_abbrev", Decl::debug_section())?;
+        obj.declare(".debug_info", Decl::debug_section())?;
+        obj.declare(".debug_str", Decl::debug_section())?;
 
         obj.define(".debug_str",
             concat![

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -851,10 +851,10 @@ pub fn to_bytes(artifact: &Artifact) -> Result<Vec<u8>, Error> {
     let mut elf = Elf::new(&artifact);
     for def in artifact.definitions() {
         debug!("Def: {:?}", def);
-        if let DefinedDecl::DebugSection = def.adecl {
-            elf.add_section(def.name, def.data, def.adecl);
+        if let DefinedDecl::DebugSection { .. } = def.decl {
+            elf.add_section(def.name, def.data, def.decl);
         } else {
-            elf.add_definition(def.name, def.data, def.adecl);
+            elf.add_definition(def.name, def.data, def.decl);
         }
     }
     for (ref import, ref kind) in artifact.imports() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(missing_docs)]
+//! Faerie is a crate for creating object files.
+
 extern crate goblin;
 extern crate indexmap;
 extern crate scroll;
@@ -15,6 +18,7 @@ type Ctx = container::Ctx;
 mod elf;
 mod mach;
 mod target;
+
 
 pub mod artifact;
 pub use crate::artifact::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@ mod elf;
 mod mach;
 mod target;
 
-
 pub mod artifact;
 pub use crate::artifact::{
     decl::{

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -1,6 +1,6 @@
 //! The Mach 32/64 bit backend for transforming an artifact to a valid, mach-o object file.
 
-use crate::artifact::{ADecl, Decl, Definition, ImportKind, Reloc};
+use crate::artifact::{DefinedDecl, Decl, Definition, ImportKind, Reloc};
 use crate::target::make_ctx;
 use crate::{Artifact, Ctx};
 
@@ -427,7 +427,7 @@ impl SegmentBuilder {
         let mut local_size = 0;
         let mut segment_relative_offset = 0;
         for def in definitions {
-            if let ADecl::DebugSection { .. } = def.adecl {
+            if let DefinedDecl::DebugSection { .. } = def.adecl {
                 unimplemented!("debug sections for mach backend")
             }
             local_size += def.data.len() as u64;
@@ -571,16 +571,16 @@ impl<'a> Mach<'a> {
             (Vec::new(), Vec::new(), Vec::new(), Vec::new());
         for def in artifact.definitions() {
             match def.adecl {
-                ADecl::Function { .. } => {
+                DefinedDecl::Function { .. } => {
                     code.push(def);
                 }
-                ADecl::Data { .. } => {
+                DefinedDecl::Data { .. } => {
                     data.push(def);
                 }
-                ADecl::CString { .. } => {
+                DefinedDecl::CString { .. } => {
                     cstrings.push(def);
                 }
-                ADecl::DebugSection { .. } => {
+                DefinedDecl::DebugSection { .. } => {
                     debug.push(def);
                 }
             }
@@ -786,32 +786,32 @@ fn build_relocations(segment: &mut SegmentBuilder, artifact: &Artifact, symtab: 
                 // NB: we currently deduce the meaning of our relocation from from decls -> to decl relocations
                 // e.g., global static data references, are constructed from Data -> Data links
                 match (link.from.decl, link.to.decl) {
-                    (Decl::Artifact(ADecl::DebugSection { .. }), _) => {
+                    (Decl::Defined(DefinedDecl::DebugSection { .. }), _) => {
                         panic!("must use Reloc::Debug for debug section links")
                     }
                     // only debug sections should link to debug sections
-                    (_, Decl::Artifact(ADecl::DebugSection { .. })) => {
+                    (_, Decl::Defined(DefinedDecl::DebugSection { .. })) => {
                         panic!("invalid DebugSection link")
                     }
                     // various static function pointers in the .data section
                     (
-                        Decl::Artifact(ADecl::Data { .. }),
-                        Decl::Artifact(ADecl::Function { .. }),
+                        Decl::Defined(DefinedDecl::Data { .. }),
+                        Decl::Defined(DefinedDecl::Function { .. }),
                     ) => (true, X86_64_RELOC_UNSIGNED),
                     (
-                        Decl::Artifact(ADecl::Data { .. }),
+                        Decl::Defined(DefinedDecl::Data { .. }),
                         Decl::Import(ImportKind::Function { .. }),
                     ) => (true, X86_64_RELOC_UNSIGNED),
                     // anything else is just a regular relocation/callq
-                    (_, Decl::Artifact(ADecl::Function { .. })) => (false, X86_64_RELOC_BRANCH),
+                    (_, Decl::Defined(DefinedDecl::Function { .. })) => (false, X86_64_RELOC_BRANCH),
                     // we are a relocation in the data section to another object
                     // in the data section, e.g., a static reference
-                    (Decl::Artifact(ADecl::Data { .. }), Decl::Artifact(ADecl::Data { .. })) => {
+                    (Decl::Defined(DefinedDecl::Data { .. }), Decl::Defined(DefinedDecl::Data { .. })) => {
                         (true, X86_64_RELOC_UNSIGNED)
                     }
-                    (_, Decl::Artifact(ADecl::Data { .. })) => (false, X86_64_RELOC_SIGNED),
+                    (_, Decl::Defined(DefinedDecl::Data { .. })) => (false, X86_64_RELOC_SIGNED),
                     // TODO: we will also need to specify relocations from Data to Cstrings, e.g., char * STR = "a global static string";
-                    (_, Decl::Artifact(ADecl::CString { .. })) => (false, X86_64_RELOC_SIGNED),
+                    (_, Decl::Defined(DefinedDecl::CString { .. })) => (false, X86_64_RELOC_SIGNED),
                     (_, Decl::Import(ImportKind::Function)) => (false, X86_64_RELOC_BRANCH),
                     (_, Decl::Import(ImportKind::Data)) => (false, X86_64_RELOC_GOT_LOAD),
                 }

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -427,7 +427,7 @@ impl SegmentBuilder {
         let mut local_size = 0;
         let mut segment_relative_offset = 0;
         for def in definitions {
-            if let DefinedDecl::DebugSection { .. } = def.adecl {
+            if let DefinedDecl::DebugSection { .. } = def.decl {
                 unimplemented!("debug sections for mach backend")
             }
             local_size += def.data.len() as u64;
@@ -437,7 +437,7 @@ impl SegmentBuilder {
                     section,
                     segment_relative_offset,
                     absolute_offset: *symbol_offset,
-                    global: def.adecl.is_global(),
+                    global: def.decl.is_global(),
                 },
             );
             *symbol_offset += def.data.len() as u64;
@@ -570,7 +570,7 @@ impl<'a> Mach<'a> {
         let (mut code, mut data, mut cstrings, mut debug) =
             (Vec::new(), Vec::new(), Vec::new(), Vec::new());
         for def in artifact.definitions() {
-            match def.adecl {
+            match def.decl {
                 DefinedDecl::Function { .. } => {
                     code.push(def);
                 }

--- a/tests/elf.rs
+++ b/tests/elf.rs
@@ -14,7 +14,7 @@ use goblin::elf::*;
 fn file_name_is_same_as_symbol_name_issue_31() {
     const NAME: &str = "a";
     let mut obj = Artifact::new(triple!("x86_64-unknown-unknown-unknown-elf"), "a".into());
-    obj.declare(NAME, Decl::Function { global: true })
+    obj.declare(NAME, Decl::function().global())
         .expect("can declare");
     obj.define(NAME, vec![1, 2, 3, 4]).expect("can define");
     println!("\n{:#?}", obj);
@@ -54,9 +54,9 @@ fn file_name_is_same_as_symbol_name_issue_31() {
 fn link_symbol_pair_panic_issue_30() {
     let mut obj = Artifact::new(triple!("x86_64-unknown-unknown-unknown-elf"), "t.o".into());
 
-    obj.declare("a", Decl::Function { global: true })
+    obj.declare("a", Decl::function().global())
         .expect("can declare a");
-    obj.declare_with("b", Decl::Function { global: true }, vec![1, 2, 3, 4])
+    obj.declare_with("b", Decl::function().global(), vec![1, 2, 3, 4])
         .expect("can declare and define b");
 
     obj.link(Link {


### PR DESCRIPTION
The goal of this is to replace `artifact::Prop` with `artifact::ADecl`, where ADecl is a new enum introduced with just the artifact-defined variants of `Decl`.

* Eliminates invariant on structure of `Prop` by keeping two sets and iterating through them with in sequence
* Changes `Decl` to be just two variants: `Import(ImportKind), Artifact(ADecl)`
* delete `artifact::Prop` and just use `ADecl` in its place all the way into the backends.

This enables:

* Some general refactoring, and fixing FIXMEs, in elf.rs.
* We can start putting the additional attributes that backends need into the ADecl fields.
* We can eliminate the special case of CString data by making string contents an attribute of Data

This brought up an important question:

* Do imports belong in Decl at all? Can we expose a different method `Artifact::import(&mut self, name: &str, kind: ImportKind)`, so that the awkward `ADecl` enum can be renamed `Decl`? This would break more library consumers, but, I'm on board to fix all this stuff throughout Cranelift
