### PR TITLE
Expand declaration attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "faerie"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["m4b <m4b.github.io@gmail.com>", "Dan Gohman <sunfish@mozilla.com>", "Pat Hickey <pat@moreproductive.org>", "Philip Craig <philipjcraig@gmail.com>"]
 readme = "README.md"
 keywords = ["elf", "mach-o", "binary", "object", "compiler"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ name = "prototype"
 path = "src/bin/main.rs"
 
 [dependencies]
-goblin = "0.0.19"
+goblin = "0.0.21"
 scroll = "0.9"
 log = "0.4"
 env_logger = "0.5"

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ let mut obj = ArtifactBuilder::new(triple!("x86_64-unknown-unknown-unknown-elf")
 // it is a runtime error to define a symbol _without_ declaring it first
 obj.declarations(
     [
-        ("deadbeef", Decl::Function { global: false }),
-        ("main",     Decl::Function { global: true }),
-        ("str.1",    Decl::CString { global: false }),
-        ("DEADBEEF", Decl::DataImport),
-        ("printf",   Decl::FunctionImport),
+        ("deadbeef", Decl::function().into()),
+        ("main",     Decl::function().global().into()),
+        ("str.1",    Decl::cstring().into()),
+        ("DEADBEEF", Decl::data_import()),
+        ("printf",   Decl::function_import()),
     ].into_iter().cloned()
 )?;
 
@@ -89,7 +89,7 @@ e_phoff: <font color="#C4A000">0x0</font> e_shoff: <font color="#C4A000">0x2a2</
   <span style="background-color:#D3D7CF"><font color="#2E3436">0  </font></span>   <span style="background-color:#D3D7CF"><font color="#2E3436">               </font></span>       SHT_NULL                          <font color="#C4A000">0x0   </font>   <font color="#CC0000"><b>0x0 </b></font>   <font color="#4E9A06"><b>0x0  </b></font>                0x0       0x0    
   <span style="background-color:#2E3436"><font color="#D3D7CF">1  </font></span>   <span style="background-color:#2E3436"><font color="#D3D7CF">.strtab        </font></span>     SHT_STRTAB                          <font color="#C4A000">0x8c  </font>   <font color="#CC0000"><b>0x0 </b></font>   <font color="#4E9A06"><b>0xc6 </b></font>                0x0       0x1    
   <span style="background-color:#D3D7CF"><font color="#2E3436">2  </font></span>   <span style="background-color:#D3D7CF"><font color="#2E3436">.symtab        </font></span>     SHT_SYMTAB                          <font color="#C4A000">0x152 </font>   <font color="#CC0000"><b>0x0 </b></font>   <font color="#4E9A06"><b>0xf0 </b></font>   .strtab(1)   0x18      0x8    
-  <span style="background-color:#2E3436"><font color="#D3D7CF">3  </font></span>   <span style="background-color:#2E3436"><font color="#D3D7CF">.data.str.1    </font></span>   SHT_PROGBITS   <b>ALLOC MERGE STRINGS </b>   <font color="#C4A000">0x40  </font>   <font color="#CC0000"><b>0x0 </b></font>   <font color="#4E9A06"><b>0x10 </b></font>                0x1       0x1    
+  <span style="background-color:#2E3436"><font color="#D3D7CF">3  </font></span>   <span style="background-color:#2E3436"><font color="#D3D7CF">.rodata.str.1    </font></span>   SHT_PROGBITS   <b>ALLOC MERGE STRINGS </b>   <font color="#C4A000">0x40  </font>   <font color="#CC0000"><b>0x0 </b></font>   <font color="#4E9A06"><b>0x10 </b></font>                0x1       0x1    
   <span style="background-color:#D3D7CF"><font color="#2E3436">4  </font></span>   <span style="background-color:#D3D7CF"><font color="#2E3436">.text.deadbeef </font></span>   SHT_PROGBITS   <b>ALLOC EXECINSTR     </b>   <font color="#C4A000">0x50  </font>   <font color="#CC0000"><b>0x0 </b></font>   <font color="#4E9A06"><b>0x14 </b></font>                0x0       0x10   
   <span style="background-color:#2E3436"><font color="#D3D7CF">5  </font></span>   <span style="background-color:#2E3436"><font color="#D3D7CF">.text.main     </font></span>   SHT_PROGBITS   <b>ALLOC EXECINSTR     </b>   <font color="#C4A000">0x64  </font>   <font color="#CC0000"><b>0x0 </b></font>   <font color="#4E9A06"><b>0x28 </b></font>                0x0       0x10   
   <span style="background-color:#D3D7CF"><font color="#2E3436">6  </font></span>   <span style="background-color:#D3D7CF"><font color="#2E3436">.reloc.main    </font></span>       SHT_RELA                          <font color="#C4A000">0x242 </font>   <font color="#CC0000"><b>0x0 </b></font>   <font color="#4E9A06"><b>0x48 </b></font>   .symtab(2)   0x18      0x8    
@@ -100,10 +100,10 @@ e_phoff: <font color="#C4A000">0x0</font> e_shoff: <font color="#C4A000">0x2a2</
   <b>             Addr</b>   <b>Bind    </b>   <b>Type     </b>   <b>Symbol  </b>   <b>Size </b>   <b>Section          </b>   <b>Other</b>  
   <font color="#CC0000">               0 </font>   <span style="background-color:#34E2E2"><font color="#555753"><b>LOCAL   </b></font></span>   NOTYPE                 <font color="#4E9A06">0x0  </font>                       0x0    
   <font color="#CC0000">               0 </font>   <span style="background-color:#34E2E2"><font color="#555753"><b>LOCAL   </b></font></span>   FILE        <font color="#FCE94F"><b>test.o  </b></font>   <font color="#4E9A06">0x0  </font>   <font color="#D3D7CF"><i>ABS              </i></font>   0x0    
-  <font color="#CC0000">               0 </font>   <span style="background-color:#34E2E2"><font color="#555753"><b>LOCAL   </b></font></span>   SECTION                <font color="#4E9A06">0x0  </font>   .data.str.1(3)      0x0    
+  <font color="#CC0000">               0 </font>   <span style="background-color:#34E2E2"><font color="#555753"><b>LOCAL   </b></font></span>   SECTION                <font color="#4E9A06">0x0  </font>   .rodata.str.1(3)      0x0    
   <font color="#CC0000">               0 </font>   <span style="background-color:#34E2E2"><font color="#555753"><b>LOCAL   </b></font></span>   SECTION                <font color="#4E9A06">0x0  </font>   .text.deadbeef(4)   0x0    
   <font color="#CC0000">               0 </font>   <span style="background-color:#34E2E2"><font color="#555753"><b>LOCAL   </b></font></span>   SECTION                <font color="#4E9A06">0x0  </font>   .text.main(5)       0x0    
-  <font color="#CC0000">               0 </font>   <span style="background-color:#34E2E2"><font color="#555753"><b>LOCAL   </b></font></span>   <font color="#FCE94F"><b>OBJECT   </b></font>   <font color="#FCE94F"><b>str.1   </b></font>   <font color="#4E9A06">0x10 </font>   .data.str.1(3)      0x0    
+  <font color="#CC0000">               0 </font>   <span style="background-color:#34E2E2"><font color="#555753"><b>LOCAL   </b></font></span>   <font color="#FCE94F"><b>OBJECT   </b></font>   <font color="#FCE94F"><b>str.1   </b></font>   <font color="#4E9A06">0x10 </font>   .rodata.str.1(3)      0x0    
   <font color="#CC0000">               0 </font>   <span style="background-color:#34E2E2"><font color="#555753"><b>LOCAL   </b></font></span>   <font color="#EF2929"><b>FUNC     </b></font>   <font color="#FCE94F"><b>deadbeef</b></font>   <font color="#4E9A06">0x14 </font>   .text.deadbeef(4)   0x0    
   <font color="#CC0000">               0 </font>   <span style="background-color:#EF2929"><font color="#555753"><b>GLOBAL  </b></font></span>   <font color="#EF2929"><b>FUNC     </b></font>   <font color="#FCE94F"><b>main    </b></font>   <font color="#4E9A06">0x28 </font>   .text.main(5)       0x0    
   <font color="#CC0000">               0 </font>   <span style="background-color:#EF2929"><font color="#555753"><b>GLOBAL  </b></font></span>   NOTYPE      <font color="#FCE94F"><b>DEADBEEF</b></font>   <font color="#4E9A06">0x0  </font>                       0x0    
@@ -111,7 +111,7 @@ e_phoff: <font color="#C4A000">0x0</font> e_shoff: <font color="#C4A000">0x2a2</
 
 <font color="#D3D7CF">Shdr Relocations(4)</font>:
 <font color="#D3D7CF"><b>  .text.main</b></font>(3)
-<font color="#CC0000">              13</font> X86_64_PC32 <font color="#C4A000"><b>.data.str.1</b></font>
+<font color="#CC0000">              13</font> X86_64_PC32 <font color="#C4A000"><b>.rodata.str.1</b></font>
 <font color="#CC0000">              1d</font> X86_64_PLT32 <font color="#C4A000"><b>printf</b></font>+<font color="#CC0000">-4</font>
 <font color="#CC0000">               a</font> X86_64_PLT32 <font color="#C4A000"><b>.text.deadbeef</b></font>+<font color="#CC0000">-4</font>
 

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -12,7 +12,7 @@ use std::io::Write;
 use crate::{elf, mach};
 
 pub(crate) mod decl;
-pub use decl::{DataType, Decl, DefinedDecl, ImportKind, Scope, Visibility};
+pub use crate::artifact::decl::{DataType, Decl, DefinedDecl, ImportKind, Scope, Visibility};
 
 /// A blob of binary bytes, representing a function body, or data object
 pub type Data = Vec<u8>;

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -282,7 +282,7 @@ impl Artifact {
     }
     /// Declare a new symbolic reference, with the given `decl`.
     /// **Note**: All declarations _must_ precede their definitions.
-    pub fn declare<T: AsRef<str>, D: Into<Decl>>(&mut self, name: T, decl: D) -> Result<(), Error> {
+    pub fn declare<T: AsRef<str>, D: Into<Decl>>(&mut self, name: T, decl: D) -> Result<(), ArtifactError> {
         let decl = decl.into();
         let decl_name = self.strings.get_or_intern(name.as_ref());
         let previous_was_import;

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -12,7 +12,7 @@ use std::io::Write;
 use crate::{elf, mach};
 
 pub(crate) mod decl;
-pub use decl::{Decl, DefinedDecl, ImportKind, Scope, Visibility};
+pub use decl::{DataType, Decl, DefinedDecl, ImportKind, Scope, Visibility};
 
 /// A blob of binary bytes, representing a function body, or data object
 pub type Data = Vec<u8>;

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -12,7 +12,7 @@ use std::io::Write;
 use crate::{elf, mach};
 
 pub(crate) mod decl;
-pub use decl::{Decl, DefinedDecl, ImportKind};
+pub use decl::{Decl, DefinedDecl, ImportKind, Scope, Visibility};
 
 /// A blob of binary bytes, representing a function body, or data object
 pub type Data = Vec<u8>;

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -282,7 +282,11 @@ impl Artifact {
     }
     /// Declare a new symbolic reference, with the given `decl`.
     /// **Note**: All declarations _must_ precede their definitions.
-    pub fn declare<T: AsRef<str>, D: Into<Decl>>(&mut self, name: T, decl: D) -> Result<(), ArtifactError> {
+    pub fn declare<T: AsRef<str>, D: Into<Decl>>(
+        &mut self,
+        name: T,
+        decl: D,
+    ) -> Result<(), ArtifactError> {
         let decl = decl.into();
         let decl_name = self.strings.get_or_intern(name.as_ref());
         let previous_was_import;

--- a/src/artifact/decl.rs
+++ b/src/artifact/decl.rs
@@ -382,6 +382,24 @@ pub struct DataDecl {
     datatype: DataType,
 }
 
+macro_rules! datatype_methods {
+    () => {
+    /// Build datatype
+    pub fn with_datatype(mut self, datatype: DataType) -> Self {
+        self.datatype = datatype;
+        self
+    }
+    /// Set datatype
+    pub fn set_datatype(&mut self, datatype: DataType) {
+        self.datatype = datatype;
+    }
+    /// Get datatype
+    pub fn get_datatype(&self) -> DataType {
+        self.datatype
+    }
+    }
+}
+
 impl Default for DataDecl {
     fn default() -> Self {
         DataDecl {
@@ -396,6 +414,7 @@ impl Default for DataDecl {
 impl DataDecl {
     scope_methods!();
     visibility_methods!();
+    datatype_methods!();
     /// Set mutability to writable
     pub fn writable(mut self) -> Self {
         self.writable = true;
@@ -411,19 +430,6 @@ impl DataDecl {
         self.writable
     }
 
-    /// Build datatype
-    pub fn with_datatype(mut self, datatype: DataType) -> Self {
-        self.datatype = datatype;
-        self
-    }
-    /// Set datatype
-    pub fn set_datatype(&mut self, datatype: DataType) {
-        self.datatype = datatype;
-    }
-    /// Get datatype
-    pub fn get_datatype(&self) -> DataType {
-        self.datatype
-    }
 }
 
 impl Into<Decl> for DataDecl {
@@ -435,9 +441,10 @@ impl Into<Decl> for DataDecl {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 /// Builder for a debug section declaration
-pub struct DebugSectionDecl {}
+pub struct DebugSectionDecl { datatype: DataType }
 
 impl DebugSectionDecl {
+    datatype_methods!();
     /// Debug sections are never global, but we have an accessor
     /// for symmetry with other section declarations
     pub fn is_global(&self) -> bool {
@@ -447,7 +454,7 @@ impl DebugSectionDecl {
 
 impl Default for DebugSectionDecl {
     fn default() -> Self {
-        DebugSectionDecl {}
+        DebugSectionDecl { datatype: DataType::Bytes }
     }
 }
 

--- a/src/artifact/decl.rs
+++ b/src/artifact/decl.rs
@@ -36,7 +36,8 @@ pub enum Scope {
     /// Available only inside the defining component
     Local,
     /// Available to all modules, but only selected if a Global
-    /// definition is not found
+    /// definition is not found. No conflict if there are multiple
+    /// weak symbols.
     Weak,
 }
 
@@ -67,7 +68,7 @@ macro_rules! scope_methods {
     pub fn set_scope(&mut self, scope: Scope) {
         self.scope = scope;
     }
-    /// Check if scope is `Scope::Global`
+    /// Check if scope is `Scope::Global`. False if set to Local or Weak.
     pub fn is_global(&self) -> bool {
         self.scope == Scope::Global
     }
@@ -120,7 +121,7 @@ macro_rules! visibility_methods {
 pub enum DataType {
     /// Ordinary raw bytes
     Bytes,
-    /// 0-terminated ascii string
+    /// 0-terminated C-style string.
     String,
 }
 
@@ -144,7 +145,8 @@ macro_rules! datatype_methods {
 
 macro_rules! align_methods {
     () => {
-    /// Build alignment
+    /// Build alignment. Size is in bytes. If None, a default is chosen
+    /// in the backend.
     pub fn with_align(mut self, align: Option<usize>) -> Self {
         self.align = align;
         self

--- a/src/artifact/decl.rs
+++ b/src/artifact/decl.rs
@@ -437,15 +437,22 @@ impl DataDecl {
     visibility_methods!();
     datatype_methods!();
     align_methods!();
-    /// Set mutability to writable
-    pub fn writable(mut self) -> Self {
-        self.writable = true;
+    /// Builder for writability
+    pub fn with_writable(mut self, writable: bool) -> Self {
+        self.writable = writable;
         self
     }
+    /// Set mutability to writable
+    pub fn writable(self) -> Self {
+        self.with_writable(true)
+    }
     /// Set mutability to read-only
-    pub fn read_only(mut self) -> Self {
-        self.writable = false;
-        self
+    pub fn read_only(self) -> Self {
+        self.with_writable(false)
+    }
+    /// Setter for mutability
+    pub fn set_writable(&mut self, writable: bool) {
+        self.writable = writable;
     }
     /// Accessor for mutability
     pub fn is_writable(&self) -> bool {

--- a/src/artifact/decl.rs
+++ b/src/artifact/decl.rs
@@ -1,5 +1,4 @@
 use crate::artifact::ArtifactError;
-use failure::Error;
 
 /// The kind of declaration this is
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -254,7 +253,7 @@ impl Decl {
     /// 4. Anything else is a [IncompatibleDeclaration](enum.ArtifactError.html#variant.IncompatibleDeclaration) error!
     // ref https://github.com/m4b/faerie/issues/24
     // ref https://github.com/m4b/faerie/issues/18
-    pub fn absorb(&mut self, other: Self) -> Result<(), Error> {
+    pub fn absorb(&mut self, other: Self) -> Result<(), ArtifactError> {
         // FIXME: i can't think of a way offhand to not clone here, without unusual contortions
         match self.clone() {
             Decl::Import(ImportKind::Data) => {

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -120,7 +120,7 @@ impl<'a> SymbolBuilder<'a> {
         use goblin::elf::section_header::SHN_ABS;
         use goblin::elf::sym::{
             STB_GLOBAL, STB_LOCAL, STB_WEAK, STT_FILE, STT_FUNC, STT_NOTYPE, STT_OBJECT,
-            STT_SECTION, STV_DEFAULT, STV_HIDDEN, STV_PROTECTED
+            STT_SECTION, STV_DEFAULT, STV_HIDDEN, STV_PROTECTED,
         };
         let mut st_shndx = self.shndx;
         let mut st_info = 0;
@@ -501,18 +501,19 @@ impl<'a> Elf<'a> {
                 .writable(d.is_writable())
                 .exec(false)
                 .align(d.get_align()),
-            DefinedDecl::DebugSection(d) => SectionBuilder::new(def_size as u64).section_type(
-                // TODO: this behavior should be deprecated, but we need to warn users!
-                if name == ".debug_str" || name == ".debug_line_str" {
-                    SectionType::String
-                } else {
-                    match d.get_datatype() {
-                        DataType::Bytes => SectionType::Bits,
-                        DataType::String => SectionType::String,
-                    }
-                },
-            )
-            .align(d.get_align()),
+            DefinedDecl::DebugSection(d) => SectionBuilder::new(def_size as u64)
+                .section_type(
+                    // TODO: this behavior should be deprecated, but we need to warn users!
+                    if name == ".debug_str" || name == ".debug_line_str" {
+                        SectionType::String
+                    } else {
+                        match d.get_datatype() {
+                            DataType::Bytes => SectionType::Bits,
+                            DataType::String => SectionType::String,
+                        }
+                    },
+                )
+                .align(d.get_align()),
         };
 
         let shndx = self.add_progbits(section_name, section, data);

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -114,6 +114,7 @@ impl<'a> SymbolBuilder<'a> {
         };
         let mut st_shndx = 0;
         let mut st_info = 0;
+        let mut st_other = 0;
         let st_value = 0;
 
         fn scope_stb_flags(s: Scope) -> u8 {
@@ -125,18 +126,30 @@ impl<'a> SymbolBuilder<'a> {
             flag << 4
         }
 
+        // TODO put these into goblin
+        fn vis_stother_flags(v: Visibility) -> u8 {
+            match v {
+                Visibility::Default => 0,
+                Visibility::Hidden => 2,
+                Visibility::Protected => 3,
+            }
+        }
+
         match self.typ {
             SymbolType::Decl(DefinedDecl::Function(d)) => {
                 st_info |= STT_FUNC;
                 st_info |= scope_stb_flags(d.get_scope());
+                st_other |= vis_stother_flags(d.get_visibility());
             }
             SymbolType::Decl(DefinedDecl::Data(d)) => {
                 st_info |= STT_OBJECT;
                 st_info |= scope_stb_flags(d.get_scope());
+                st_other |= vis_stother_flags(d.get_visibility());
             }
             SymbolType::Decl(DefinedDecl::CString(d)) => {
                 st_info |= STT_OBJECT;
                 st_info |= scope_stb_flags(d.get_scope());
+                st_other |= vis_stother_flags(d.get_visibility());
             }
             SymbolType::Import => {
                 st_info = STT_NOTYPE;
@@ -155,7 +168,7 @@ impl<'a> SymbolBuilder<'a> {
         }
         Symbol {
             st_name: self.name_offset,
-            st_other: 0,
+            st_other,
             st_size: self.size,
             st_info,
             st_shndx,

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -486,11 +486,12 @@ impl<'a> Elf<'a> {
         };
 
         let section = match decl {
-            DefinedDecl::Function(_) => SectionBuilder::new(def_size as u64)
+            DefinedDecl::Function(d) => SectionBuilder::new(def_size as u64)
                 .section_type(SectionType::Bits)
                 .alloc()
                 .writable(false)
-                .exec(true),
+                .exec(true)
+                .align(d.get_align()),
             DefinedDecl::Data(d) => SectionBuilder::new(def_size as u64)
                 .section_type(match d.get_datatype() {
                     DataType::Bytes => SectionType::Data,
@@ -498,7 +499,8 @@ impl<'a> Elf<'a> {
                 })
                 .alloc()
                 .writable(d.is_writable())
-                .exec(false),
+                .exec(false)
+                .align(d.get_align()),
             DefinedDecl::DebugSection(d) => SectionBuilder::new(def_size as u64).section_type(
                 // TODO: this behavior should be deprecated, but we need to warn users!
                 if name == ".debug_str" || name == ".debug_line_str" {
@@ -509,7 +511,8 @@ impl<'a> Elf<'a> {
                         DataType::String => SectionType::String,
                     }
                 },
-            ),
+            )
+            .align(d.get_align()),
         };
 
         let shndx = self.add_progbits(section_name, section, data);

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -120,7 +120,7 @@ impl<'a> SymbolBuilder<'a> {
         use goblin::elf::section_header::SHN_ABS;
         use goblin::elf::sym::{
             STB_GLOBAL, STB_LOCAL, STB_WEAK, STT_FILE, STT_FUNC, STT_NOTYPE, STT_OBJECT,
-            STT_SECTION,
+            STT_SECTION, STV_DEFAULT, STV_HIDDEN, STV_PROTECTED
         };
         let mut st_shndx = self.shndx;
         let mut st_info = 0;
@@ -136,12 +136,11 @@ impl<'a> SymbolBuilder<'a> {
             flag << 4
         }
 
-        // TODO put these into goblin
         fn vis_stother_flags(v: Visibility) -> u8 {
             match v {
-                Visibility::Default => 0,
-                Visibility::Hidden => 2,
-                Visibility::Protected => 3,
+                Visibility::Default => STV_DEFAULT,
+                Visibility::Hidden => STV_HIDDEN,
+                Visibility::Protected => STV_PROTECTED,
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,8 @@ mod target;
 pub mod artifact;
 pub use crate::artifact::{
     decl::{
-        CStringDecl, DataDecl, DataImportDecl, DebugSectionDecl, Decl, FunctionDecl,
-        FunctionImportDecl,
+        DataDecl, DataImportDecl, DataType, DebugSectionDecl, Decl, FunctionDecl,
+        FunctionImportDecl, Scope, Visibility,
     },
     Artifact, ArtifactBuilder, ImportKind, Link, Reloc,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,5 +25,5 @@ pub use crate::artifact::{
         DataDecl, DataImportDecl, DataType, DebugSectionDecl, Decl, FunctionDecl,
         FunctionImportDecl, Scope, Visibility,
     },
-    Artifact, ArtifactBuilder, ImportKind, Link, Reloc,
+    Artifact, ArtifactBuilder, ArtifactError, ImportKind, Link, Reloc,
 };

--- a/tests/elf.rs
+++ b/tests/elf.rs
@@ -75,14 +75,16 @@ fn link_symbol_pair_panic_issue_30() {
     assert!(obj.emit().is_err());
 }
 
-
 #[test]
 fn decl_attributes() {
     decl_tests(vec![
         DeclTestCase::new("weak_func", Decl::function().weak(), |sym, sect| {
             ensure!(sym.is_function(), "symbol is function");
             ensure!(sym.st_bind() == sym::STB_WEAK, "symbol is weak");
-            ensure!(sym.st_visibility() == sym::STV_DEFAULT, "symbol is default vis");
+            ensure!(
+                sym.st_visibility() == sym::STV_DEFAULT,
+                "symbol is default vis"
+            );
             ensure!(sect.is_executable(), "executable");
             ensure!(!sect.is_writable(), "immutable");
             Ok(())
@@ -90,23 +92,36 @@ fn decl_attributes() {
         DeclTestCase::new("weak_data", Decl::data().weak(), |sym, sect| {
             ensure!(sym.st_type() == sym::STT_OBJECT, "symbol is object");
             ensure!(sym.st_bind() == sym::STB_WEAK, "symbol is weak");
-            ensure!(sym.st_visibility() == sym::STV_DEFAULT, "symbol is default vis");
+            ensure!(
+                sym.st_visibility() == sym::STV_DEFAULT,
+                "symbol is default vis"
+            );
             ensure!(!sect.is_executable(), "not executable");
             ensure!(!sect.is_writable(), "immutable");
             Ok(())
         }),
-        DeclTestCase::new("weak_data_writable", Decl::data().weak().writable(), |sym, sect| {
-            ensure!(sym.st_type() == sym::STT_OBJECT, "symbol is object");
-            ensure!(sym.st_bind() == sym::STB_WEAK, "symbol is weak");
-            ensure!(sym.st_visibility() == sym::STV_DEFAULT, "symbol is default vis");
-            ensure!(!sect.is_executable(), "not executable");
-            ensure!(sect.is_writable(), "mutable");
-            Ok(())
-        }),
+        DeclTestCase::new(
+            "weak_data_writable",
+            Decl::data().weak().writable(),
+            |sym, sect| {
+                ensure!(sym.st_type() == sym::STT_OBJECT, "symbol is object");
+                ensure!(sym.st_bind() == sym::STB_WEAK, "symbol is weak");
+                ensure!(
+                    sym.st_visibility() == sym::STV_DEFAULT,
+                    "symbol is default vis"
+                );
+                ensure!(!sect.is_executable(), "not executable");
+                ensure!(sect.is_writable(), "mutable");
+                Ok(())
+            },
+        ),
         DeclTestCase::new("weak_cstring", Decl::cstring().weak(), |sym, sect| {
             ensure!(sym.st_type() == sym::STT_OBJECT, "symbol is object");
             ensure!(sym.st_bind() == sym::STB_WEAK, "symbol is weak");
-            ensure!(sym.st_visibility() == sym::STV_DEFAULT, "symbol is default vis");
+            ensure!(
+                sym.st_visibility() == sym::STV_DEFAULT,
+                "symbol is default vis"
+            );
             ensure!(!sect.is_executable(), "not executable");
             ensure!(!sect.is_writable(), "immutable");
             Ok(())
@@ -135,57 +150,89 @@ fn decl_attributes() {
             ensure!(!sect.is_writable(), "immutable");
             Ok(())
         }),
-        DeclTestCase::new("protected_func", Decl::function().protected(), |sym, sect| {
-            ensure!(sym.is_function(), "symbol is func");
-            ensure!(sym.st_bind() == sym::STB_LOCAL, "symbol is local");
-            ensure!(sym.st_visibility() == sym::STV_PROTECTED, "symbol is protected");
-            ensure!(sect.is_executable(), "executable");
-            ensure!(!sect.is_writable(), "immutable");
-            Ok(())
-        }),
+        DeclTestCase::new(
+            "protected_func",
+            Decl::function().protected(),
+            |sym, sect| {
+                ensure!(sym.is_function(), "symbol is func");
+                ensure!(sym.st_bind() == sym::STB_LOCAL, "symbol is local");
+                ensure!(
+                    sym.st_visibility() == sym::STV_PROTECTED,
+                    "symbol is protected"
+                );
+                ensure!(sect.is_executable(), "executable");
+                ensure!(!sect.is_writable(), "immutable");
+                Ok(())
+            },
+        ),
         DeclTestCase::new("protected_data", Decl::data().protected(), |sym, sect| {
             ensure!(sym.st_type() == sym::STT_OBJECT, "symbol is object");
             ensure!(sym.st_bind() == sym::STB_LOCAL, "symbol is local");
-            ensure!(sym.st_visibility() == sym::STV_PROTECTED, "symbol is protected");
+            ensure!(
+                sym.st_visibility() == sym::STV_PROTECTED,
+                "symbol is protected"
+            );
             ensure!(!sect.is_executable(), "not executable");
             ensure!(!sect.is_writable(), "immutable");
             Ok(())
         }),
-        DeclTestCase::new("protected_cstring", Decl::cstring().protected(), |sym, sect| {
-            ensure!(sym.st_type() == sym::STT_OBJECT, "symbol is object");
-            ensure!(sym.st_bind() == sym::STB_LOCAL, "symbol is weak");
-            ensure!(sym.st_visibility() == sym::STV_PROTECTED, "symbol is protected");
-            ensure!(!sect.is_executable(), "not executable");
-            ensure!(!sect.is_writable(), "immutable");
-            Ok(())
-        }),
+        DeclTestCase::new(
+            "protected_cstring",
+            Decl::cstring().protected(),
+            |sym, sect| {
+                ensure!(sym.st_type() == sym::STT_OBJECT, "symbol is object");
+                ensure!(sym.st_bind() == sym::STB_LOCAL, "symbol is weak");
+                ensure!(
+                    sym.st_visibility() == sym::STV_PROTECTED,
+                    "symbol is protected"
+                );
+                ensure!(!sect.is_executable(), "not executable");
+                ensure!(!sect.is_writable(), "immutable");
+                Ok(())
+            },
+        ),
         DeclTestCase::new("ordinary_func", Decl::function(), |sym, sect| {
             ensure!(sym.is_function(), "symbol is function");
             ensure!(sym.st_bind() == sym::STB_LOCAL, "symbol is local");
-            ensure!(sym.st_visibility() == sym::STV_DEFAULT, "symbol is default vis");
+            ensure!(
+                sym.st_visibility() == sym::STV_DEFAULT,
+                "symbol is default vis"
+            );
             ensure!(sect.is_executable(), "executable");
             ensure!(!sect.is_writable(), "immutable");
             ensure!(sect.sh_addralign == 16, "aligned to 16");
             Ok(())
         }),
-
-        DeclTestCase::new("custom_align_func", Decl::function().with_align(Some(64)), |_sym, sect| {
-            ensure!(sect.sh_addralign == 64, "expected aligned to 64, got {}", sect.sh_addralign);
-            Ok(())
-        }),
-
-        DeclTestCase::new("custom_align_data", Decl::data().with_align(Some(128)), |_sym, sect| {
-            ensure!(sect.sh_addralign == 128, "expected aligned to 128, got {}", sect.sh_addralign);
-            Ok(())
-        }),
-
+        DeclTestCase::new(
+            "custom_align_func",
+            Decl::function().with_align(Some(64)),
+            |_sym, sect| {
+                ensure!(
+                    sect.sh_addralign == 64,
+                    "expected aligned to 64, got {}",
+                    sect.sh_addralign
+                );
+                Ok(())
+            },
+        ),
+        DeclTestCase::new(
+            "custom_align_data",
+            Decl::data().with_align(Some(128)),
+            |_sym, sect| {
+                ensure!(
+                    sect.sh_addralign == 128,
+                    "expected aligned to 128, got {}",
+                    sect.sh_addralign
+                );
+                Ok(())
+            },
+        ),
     ]);
 }
 
 /* test scaffolding: */
 
 fn decl_tests(tests: Vec<DeclTestCase>) {
-
     let mut obj = Artifact::new(triple!("x86_64-unknown-unknown-unknown-elf"), "a".into());
     for t in tests.iter() {
         t.define(&mut obj);
@@ -239,7 +286,10 @@ impl DeclTestCase {
             .iter()
             .find(|sym| &elf.strtab[sym.st_name] == self.name)
             .expect("symbol should exist");
-        let sectheader = elf.section_headers.get(sym.st_shndx).expect("section header should exist");
+        let sectheader = elf
+            .section_headers
+            .get(sym.st_shndx)
+            .expect("section header should exist");
         (self.pred)(&sym, sectheader).expect(&format!("check {}", self.name))
     }
 }


### PR DESCRIPTION
Based on #67 

Adds attributes to each declaration that allow the user to control:
* Scope is one of `Scope { Global, Local, Weak }`. Local by default, `is_global()` still gives a bool. Fixes #60 
* Visibility is one of `Visibility { Default, Protected, Hidden }`. Default by default. Fixes #61 
* Optional alignment hint. The alignment hint is used if provided, otherwise the heuristic is used based on whether the section is executable or writable. Fixes #34 
* Data type (strings vs binary data) of Data and DebugSection. Default is binary data.

The data type attribute means:
* CStrings are now just an attribute on Data, rather than a totally separate variant of decl. The builder API stays the same
* Debug sections can be marked as containing strings or not, so we can eventaully remove the heuristic that marks `.debug_str` and `.debug_line_str` sections as strings automatically. This heuristic is left in place for now to minimize breakage downstream.

Additionally, non-writable data are now put in the `.rodata` segment, which means the loader will put that data in memory that is protected against writing.