### PR TITLE
Make `prototype` an example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ before_script:
 script:
   - cargo fmt -- --check
   - cargo test
-  - cargo run -- --deadbeef deadbeef.o
-  - cargo run -- --link test test.o deadbeef.o
+  - cargo run --example prototype -- --deadbeef deadbeef.o
+  - cargo run --example prototype -- --link test test.o deadbeef.o
   - ./test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,15 @@ categories = ["development-tools::debugging"]
 include = ["src/**/*", "Cargo.toml", "LICENSE", "README.md", "tests/*"]
 edition = "2018"
 
-[[bin]]
-name = "prototype"
-path = "src/bin/main.rs"
-
 [dependencies]
 goblin = "0.0.23"
 scroll = "0.9"
 log = "0.4"
-env_logger = "0.6"
 indexmap = "1"
-structopt = "0.2"
-structopt-derive = "0.2"
 string-interner = "0.6"
 failure = "0.1"
 target-lexicon = "0.4.0"
+
+[dev-dependencies]
+env_logger = "0.6"
+structopt = "0.2"

--- a/examples/prototype.rs
+++ b/examples/prototype.rs
@@ -3,7 +3,6 @@ extern crate faerie;
 extern crate failure;
 extern crate goblin;
 extern crate structopt;
-extern crate structopt_derive;
 extern crate target_lexicon;
 
 use failure::Error;


### PR DESCRIPTION
Removes structopt as a dependency of the library.

Addresses https://github.com/m4b/faerie/issues/88