### PR TITLE
Update target lexicon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ include = ["src/**/*", "Cargo.toml", "LICENSE", "README.md", "tests/*"]
 edition = "2018"
 
 [dependencies]
-goblin = "0.0.23"
+goblin = "0.0.24"
 scroll = "0.9"
 log = "0.4"
 indexmap = "1"
 string-interner = "0.6"
 failure = "0.1"
-target-lexicon = "0.4.0"
+target-lexicon = "0.8.0"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -237,14 +237,14 @@ impl Artifact {
         }
     }
     /// Get an iterator over this artifact's imports
-    pub fn imports<'a>(&'a self) -> Box<Iterator<Item = (&'a str, &'a ImportKind)> + 'a> {
+    pub fn imports<'a>(&'a self) -> Box<dyn Iterator<Item = (&'a str, &'a ImportKind)> + 'a> {
         Box::new(
             self.imports
                 .iter()
                 .map(move |&(id, ref kind)| (self.strings.resolve(id).unwrap(), kind)),
         )
     }
-    pub(crate) fn definitions<'a>(&'a self) -> Box<Iterator<Item = Definition<'a>> + 'a> {
+    pub(crate) fn definitions<'a>(&'a self) -> Box<dyn Iterator<Item = Definition<'a>> + 'a> {
         Box::new(
             self.local_definitions
                 .iter()
@@ -253,7 +253,7 @@ impl Artifact {
         )
     }
     /// Get this artifacts relocations
-    pub(crate) fn links<'a>(&'a self) -> Box<Iterator<Item = LinkAndDecl<'a>> + 'a> {
+    pub(crate) fn links<'a>(&'a self) -> Box<dyn Iterator<Item = LinkAndDecl<'a>> + 'a> {
         Box::new(
             self.links
                 .iter()

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -46,18 +46,23 @@ impl From<Architecture> for MachineTag {
         MachineTag(match architecture {
             X86_64 => EM_X86_64,
             I386 | I586 | I686 => EM_386,
-            Aarch64 => EM_AARCH64,
-            Arm | Armebv7r | Armv4t | Armv5te | Armv6 | Armv7 | Armv7r | Armv7s | Thumbv6m
-            | Thumbv7a | Thumbv7em | Thumbv7neon | Thumbv7m | Thumbv8mBase | Thumbv8mMain => EM_ARM,
-            Mips | Mipsel | Mips64 | Mips64el => EM_MIPS,
+            Aarch64(_) => EM_AARCH64,
+            Arm(_) => EM_ARM,
+            Mips | Mipsel | Mips64 | Mips64el | Mipsisa32r6 | Mipsisa32r6el | Mipsisa64r6
+            | Mipsisa64r6el => EM_MIPS,
             Powerpc => EM_PPC,
             Powerpc64 | Powerpc64le => EM_PPC64,
-            Riscv32 | Riscv32imac | Riscv32imc | Riscv64 => EM_RISCV,
+            Riscv32 | Riscv32imac | Riscv32imc | Riscv64 | Riscv32i | Riscv64gc | Riscv64imac => {
+                EM_RISCV
+            }
             S390x => EM_S390,
             Sparc => EM_SPARC,
             Sparc64 | Sparcv9 => EM_SPARCV9,
             Msp430 => EM_MSP430,
             Unknown => EM_NONE,
+            Hexagon => panic!("goblin does not have EM_HEXAGON yet"),
+            Nvptx64 => panic!("nvptx64 does not exist in ELF"),
+            AmdGcn => panic!("amdgcn does not exist in ELF"),
             Asmjs => panic!("asm.js does not exist in ELF"),
             Wasm32 => panic!("wasm32 does not exist in ELF"),
         })

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -32,10 +32,8 @@ impl From<Architecture> for CpuType {
         CpuType(match architecture {
             X86_64 => CPU_TYPE_X86_64,
             I386 | I586 | I686 => CPU_TYPE_X86,
-            Aarch64 => CPU_TYPE_ARM64,
-            Arm | Armv4t | Armv5te | Armv7 | Armv7s | Thumbv6m | Thumbv7em | Thumbv7m => {
-                CPU_TYPE_ARM
-            }
+            Aarch64(_) => CPU_TYPE_ARM64,
+            Arm(_) => CPU_TYPE_ARM,
             Sparc => CPU_TYPE_SPARC,
             Powerpc => CPU_TYPE_POWERPC,
             Powerpc64 | Powerpc64le => CPU_TYPE_POWERPC64,


### PR DESCRIPTION
This updates to target-lexicon 0.8.0 and fixes some warnings on recent stable Rust compilers.