### PR TITLE
Add support for .bss sections

### DIFF
--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -113,7 +113,7 @@ impl Data {
     ///
     /// This is different from the bytes of _memory_ for the `ZeroInit` variant,
     /// since .bss sections are only allocated at load time.
-    pub fn len(&self) -> usize {
+    pub fn file_size(&self) -> usize {
         match self {
             Data::Blob(blob) => blob.len(),
             Data::ZeroInit(_) => 0,

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -79,10 +79,10 @@ pub enum ArtifactError {
     /// A duplicate definition
     DuplicateDefinition(String),
     #[fail(
-        display = "ZeroInit data for a declaration that does not allow ZeroInit: {:?}",
+        display = "ZeroInit data is only allowed for DataDeclarations, got {:?}",
         _0
     )]
-    /// ZeroInit data for a declaration that does not allow ZeroInit
+    /// ZeroInit is only allowed for data
     InvalidZeroInit(DefinedDecl),
 
     /// A non section declaration got custom symbols during definition.
@@ -467,14 +467,17 @@ impl Artifact {
 
                 match decl {
                     DefinedDecl::Section(_) => {}
-                    DefinedDecl::Function(_) => {
-                        if let Data::ZeroInit(_) = data {
-                            return Err(ArtifactError::InvalidZeroInit(decl));
-                        }
-                    }
                     _ => {
                         if !symbols.is_empty() {
                             return Err(ArtifactError::NonSectionCustomSymbols(decl, symbols));
+                        }
+                    }
+                }
+                match decl{
+                    DefinedDecl::Data(_) => {},
+                    _ => {
+                        if let Data::ZeroInit(_) = data {
+                            return Err(ArtifactError::InvalidZeroInit(decl));
                         }
                     }
                 }

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -109,10 +109,10 @@ struct InternalDecl {
 }
 
 impl Data {
-    /// Return the length of the data stored in this object.
+    /// Return the number of bytes of _disk_ this data will use.
     ///
-    /// For `ZeroInit` variant, returns the amount of space
-    /// that would be taken up when the program is loaded into memory.
+    /// This is different from the bytes of _memory_ for the `ZeroInit` variant,
+    /// since .bss sections are only allocated at load time.
     pub fn len(&self) -> usize {
         match self {
             Data::Blob(blob) => blob.len(),

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -172,7 +172,7 @@ pub struct LinkAndDecl<'a> {
 }
 
 /// A definition of a symbol with its properties the various backends receive
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Definition<'a> {
     /// Name of symbol
     pub name: &'a str,

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -119,13 +119,27 @@ impl Data {
             Data::ZeroInit(size) => *size,
         }
     }
+    /// Return whether the data has at least one byte defined
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Data::Blob(blob) => blob.is_empty(),
+            Data::ZeroInit(size) => *size == 0,
+        }
+    }
+    /// Return whether this data is a ZeroInit variant
+    pub fn is_zero_init(&self) -> bool {
+        match self {
+            Data::ZeroInit(_) => true,
+            Data::Blob(_) => false,
+        }
+    }
 }
 
 impl InternalDecl {
     /// Wrap up a declaration. Initially marked as not defined.
     pub fn new(decl: Decl) -> Self {
         Self {
-            decl: decl,
+            decl,
             defined: false,
         }
     }
@@ -418,7 +432,7 @@ impl Artifact {
     /// # use std::collections::BTreeMap;
     /// # use std::str::FromStr;
     /// #
-    /// # use faerie::{Artifact, ArtifactBuilder, Decl, Link, SectionKind};
+    /// # use faerie::{Artifact, ArtifactBuilder, Data, Decl, Link, SectionKind};
     /// #
     /// let mut artifact = Artifact::new(target_lexicon::triple!("x86_64-apple-darwin"), "example".to_string());
     ///
@@ -426,7 +440,7 @@ impl Artifact {
     ///
     /// let mut section_symbols = BTreeMap::new();
     /// section_symbols.insert("a_symbol".to_string(), 2);
-    /// artifact.define_with_symbols(".my_section", vec![0xde, 0xad, 0xbe, 0xef], section_symbols).unwrap();
+    /// artifact.define_with_symbols(".my_section", Data::Blob(vec![0xde, 0xad, 0xbe, 0xef]), section_symbols).unwrap();
     ///
     /// let _blob = artifact.emit().unwrap();
     /// ```

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -116,7 +116,7 @@ impl Data {
     pub fn len(&self) -> usize {
         match self {
             Data::Blob(blob) => blob.len(),
-            Data::ZeroInit(size) => *size,
+            Data::ZeroInit(_) => 0,
         }
     }
     /// Return whether the data has at least one byte defined

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -108,6 +108,12 @@ struct InternalDecl {
     defined: bool,
 }
 
+impl Into<Data> for Vec<u8> {
+    fn into(self) -> Data {
+        Data::Blob(self)
+    }
+}
+
 impl Data {
     /// Return the number of bytes of _disk_ this data will use.
     ///
@@ -444,13 +450,14 @@ impl Artifact {
     ///
     /// let _blob = artifact.emit().unwrap();
     /// ```
-    pub fn define_with_symbols<T: AsRef<str>>(
+    pub fn define_with_symbols<T: AsRef<str>, D: Into<Data>>(
         &mut self,
         name: T,
-        data: Data,
+        data: D,
         symbols: BTreeMap<String, u64>,
     ) -> Result<(), ArtifactError> {
         let decl_name = self.strings.get_or_intern(name.as_ref());
+        let data = data.into();
         match self.declarations.get_mut(&decl_name) {
             Some(ref mut stype) => {
                 if stype.defined {

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -78,6 +78,12 @@ pub enum ArtifactError {
     #[fail(display = "Duplicate definition of symbol: {}", _0)]
     /// A duplicate definition
     DuplicateDefinition(String),
+    #[fail(
+        display = "ZeroInit data for a declaration that does not allow ZeroInit: {:?}",
+        _0
+    )]
+    /// ZeroInit data for a declaration that does not allow ZeroInit
+    InvalidZeroInit(DefinedDecl),
 
     /// A non section declaration got custom symbols during definition.
     #[fail(
@@ -447,6 +453,11 @@ impl Artifact {
 
                 match decl {
                     DefinedDecl::Section(_) => {}
+                    DefinedDecl::Function(_) => {
+                        if let Data::ZeroInit(_) = data {
+                            return Err(ArtifactError::InvalidZeroInit(decl));
+                        }
+                    }
                     _ => {
                         if !symbols.is_empty() {
                             return Err(ArtifactError::NonSectionCustomSymbols(decl, symbols));

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -473,8 +473,8 @@ impl Artifact {
                         }
                     }
                 }
-                match decl{
-                    DefinedDecl::Data(_) => {},
+                match decl {
+                    DefinedDecl::Data(_) => {}
                     _ => {
                         if let Data::ZeroInit(_) = data {
                             return Err(ArtifactError::InvalidZeroInit(decl));

--- a/src/artifact/decl.rs
+++ b/src/artifact/decl.rs
@@ -123,6 +123,8 @@ pub enum DataType {
     Bytes,
     /// 0-terminated C-style string.
     String,
+    /// Zero-initialized data, stored in .bss
+    ZeroInit,
 }
 
 macro_rules! datatype_methods {

--- a/src/artifact/decl.rs
+++ b/src/artifact/decl.rs
@@ -123,8 +123,6 @@ pub enum DataType {
     Bytes,
     /// 0-terminated C-style string.
     String,
-    /// Zero-initialized data, stored in .bss
-    ZeroInit,
 }
 
 macro_rules! datatype_methods {

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -498,7 +498,7 @@ impl<'a> Elf<'a> {
     pub fn add_definition(&mut self, def: artifact::Definition<'a>) {
         let name = def.name;
         let decl = def.decl;
-        let def_size = def.data.len();
+        let def_size = def.data.file_size();
 
         let section_name = match (def.data, decl) {
             (Data::Blob(_), DefinedDecl::Function(_)) => format!(".text.{}", name),

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -580,10 +580,8 @@ impl<'a> Elf<'a> {
     /// Create a progbits section (and its section symbol), and return the section index.
     fn add_progbits(&mut self, name: String, section: SectionBuilder, data: &'a [u8]) -> usize {
         let (idx, shndx) = self.add_section(name, section);
-        // store the size of this code
-        let size = data.len();
         // increment the size
-        self.sizeof_bits += size;
+        self.sizeof_bits += data.len();
 
         self.code.insert(idx, data);
         shndx
@@ -603,6 +601,7 @@ impl<'a> Elf<'a> {
             .create();
 
         let mut section = section.name_offset(offset).create(&self.ctx);
+        // the offset is the head of how many program bits we've added
         section.sh_offset = self.sizeof_bits as u64;
         self.sections.insert(
             idx,

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -539,7 +539,7 @@ impl<'a> Elf<'a> {
 
         let shndx = match def.data {
             Data::Blob(bytes) => self.add_progbits(section_name, section, bytes),
-            Data::ZeroInit(size) => self.add_bss(section_name, section, *size),
+            Data::ZeroInit(_) => self.add_bss(section_name, section),
         };
 
         match decl {
@@ -606,7 +606,7 @@ impl<'a> Elf<'a> {
         shndx
     }
     /// Create a .bss section (and its section symbol) and return the section index
-    fn add_bss(&mut self, name: String, section: SectionBuilder, size: usize) -> usize {
+    fn add_bss(&mut self, name: String, section: SectionBuilder) -> usize {
         let (idx, offset) = self.new_string(name);
         // the symbols section reference/index will be the current number of sections
         let shndx = self.sections.len() + 3; // null + strtab + symtab

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     artifact::{
-        self, Artifact, DataType, Decl, DefinedDecl, ImportKind, LinkAndDecl, Reloc, Scope,
+        self, Artifact, Data, DataType, Decl, DefinedDecl, ImportKind, LinkAndDecl, Reloc, Scope,
         Visibility,
     },
     target::make_ctx,
@@ -379,7 +379,6 @@ impl RelocationBuilder {
     }
 }
 
-//#[derive(Debug)]
 /// An intermediate ELF object file container
 struct Elf<'a> {
     name: &'a str,
@@ -526,7 +525,10 @@ impl<'a> Elf<'a> {
                 .align(d.get_align()),
         };
 
-        let shndx = self.add_progbits(section_name, section, def.data);
+        let shndx = match def.data {
+            Data::Blob(bytes) => self.add_progbits(section_name, section, bytes),
+            Data::ZeroInit(_) => unimplemented!("writing .bss section"),
+        };
 
         match decl {
             DefinedDecl::Function(_) | DefinedDecl::Data(_) => {

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -502,11 +502,13 @@ impl<'a> Elf<'a> {
 
         let section_name = match (def.data, decl) {
             (Data::Blob(_), DefinedDecl::Function(_)) => format!(".text.{}", name),
-            (Data::ZeroInit(_), DefinedDecl::Function(_)) => unreachable!("cannot define function as zero-init"),
+            (Data::ZeroInit(_), DefinedDecl::Function(_)) => {
+                unreachable!("cannot define function as zero-init")
+            }
             (Data::Blob(_), DefinedDecl::Data(decl)) => format!(
-                    ".{}.{}",
-                    if decl.is_writable() { "data" } else { "rodata" },
-                    name
+                ".{}.{}",
+                if decl.is_writable() { "data" } else { "rodata" },
+                name
             ),
             (Data::ZeroInit(_), DefinedDecl::Data(_)) => format!(".bss.{}", name),
             (_, DefinedDecl::Section(_)) => name.to_owned(),
@@ -520,7 +522,10 @@ impl<'a> Elf<'a> {
                 .exec(true)
                 .align(d.get_align()),
             DefinedDecl::Data(d) => SectionBuilder::new(def_size as u64)
-                .section_type(Self::section_type_for_data(d.get_datatype(), def.data.is_zero_init()))
+                .section_type(Self::section_type_for_data(
+                    d.get_datatype(),
+                    def.data.is_zero_init(),
+                ))
                 .alloc()
                 .writable(d.is_writable())
                 .exec(false)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,5 +25,5 @@ pub use crate::artifact::{
         DataDecl, DataImportDecl, DataType, Decl, FunctionDecl, FunctionImportDecl, Scope,
         SectionDecl, SectionKind, Visibility,
     },
-    Artifact, ArtifactBuilder, ArtifactError, ImportKind, Link, Reloc,
+    Artifact, ArtifactBuilder, ArtifactError, Data, ImportKind, Link, Reloc,
 };

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -469,9 +469,9 @@ impl SegmentBuilder {
                     global: def.decl.is_global(),
                 },
             );
-            *symbol_offset += def.data.len() as u64;
-            section_relative_offset += def.data.len() as u64;
-            local_size += def.data.len() as u64;
+            *symbol_offset += def.data.file_size() as u64;
+            section_relative_offset += def.data.file_size() as u64;
+            local_size += def.data.file_size() as u64;
 
             let next_def_alignment_exponent = std::cmp::max(
                 min_alignment_exponent,
@@ -550,7 +550,7 @@ impl SegmentBuilder {
             );
         }
 
-        let local_size = def.data.len() as u64;
+        let local_size = def.data.file_size() as u64;
         *symbol_offset += local_size;
         let section = SectionBuilder::new(sectname, segment_name, local_size)
             .offset(*offset)

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -578,7 +578,12 @@ impl SegmentBuilder {
         let mut sections = IndexMap::new();
         let mut align_pad_map = HashMap::new();
         // TODO: see if this clone can be removed
-        let zero_init_data: Vec<_> = data
+        let zeroed_data: Vec<_> = data
+            .iter()
+            .filter(|decl| decl.data.is_zero_init())
+            .cloned()
+            .collect();
+        let nonzeroed_data: Vec<_> = data
             .iter()
             .filter(|decl| !decl.data.is_zero_init())
             .cloned()
@@ -607,7 +612,7 @@ impl SegmentBuilder {
             &mut size,
             &mut symbol_offset,
             DATA_SECTION_INDEX,
-            data,
+            &nonzeroed_data,
             3,
             None,
             &mut align_pad_map,
@@ -628,14 +633,14 @@ impl SegmentBuilder {
         );
         Self::build_section(
             symtab,
-            "__DATA",
             "__bss",
+            "__DATA",
             &mut sections,
             &mut offset,
             &mut size,
             &mut symbol_offset,
             BSS_SECTION_INDEX,
-            &zero_init_data,
+            &zeroed_data,
             0,
             Some(S_ZEROFILL),
             &mut align_pad_map,

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -813,10 +813,11 @@ impl<'a> Mach<'a> {
         // write code
         //////////////////////////////
         for code in self.code {
-            match code.data {
-                Data::Blob(bytes) => file.write_all(bytes)?,
-                Data::ZeroInit(_) => unreachable!("cannot initialize code with zero-init data"),
-            };
+            if let Data::Blob(bytes) = code.data {
+                file.write_all(&bytes)?;
+            } else {
+                unreachable!()
+            }
 
             if let Some(&align_pad) = self.segment.align_pad_map.get(code.name) {
                 for _ in 0..align_pad {
@@ -853,6 +854,8 @@ impl<'a> Mach<'a> {
         for cstring in self.cstrings {
             if let Data::Blob(bytes) = cstring.data {
                 file.write_all(bytes)?;
+            } else {
+                unreachable!();
             }
 
             if let Some(&align_pad) = self.segment.align_pad_map.get(cstring.name) {
@@ -870,6 +873,8 @@ impl<'a> Mach<'a> {
         for section in self.sections {
             if let Data::Blob(bytes) = section.data {
                 file.write_all(bytes)?;
+            } else {
+                unreachable!()
             }
 
             if let Some(&align_pad) = self.segment.align_pad_map.get(section.name) {

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -1,6 +1,8 @@
 //! The Mach 32/64 bit backend for transforming an artifact to a valid, mach-o object file.
 
-use crate::artifact::{Data, DataType, Decl, DefinedDecl, Definition, ImportKind, Reloc, SectionKind};
+use crate::artifact::{
+    Data, DataType, Decl, DefinedDecl, Definition, ImportKind, Reloc, SectionKind,
+};
 use crate::target::make_ctx;
 use crate::{Artifact, Ctx};
 
@@ -575,9 +577,11 @@ impl SegmentBuilder {
         let mut sections = IndexMap::new();
         let mut align_pad_map = HashMap::new();
         // TODO: see if this clone can be removed
-        let zero_init_data: Vec<_> = data.iter()
+        let zero_init_data: Vec<_> = data
+            .iter()
             .filter(|decl| !decl.data.is_zero_init())
-            .cloned().collect();
+            .cloned()
+            .collect();
 
         Self::build_section(
             symtab,

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -786,13 +786,13 @@ impl<'a> Mach<'a> {
         // FIXME: de-magic number these
         segment_load_command.initprot = 7;
         segment_load_command.maxprot = 7;
-        segment_load_command.vmsize = self.segment.size();
-        // segment size, with __bss data sizes removed
-        segment_load_command.filesize = {
-            let mut acc = segment_load_command.vmsize;
+        segment_load_command.filesize = self.segment.size();
+        // segment size, with __bss data sizes added
+        segment_load_command.vmsize = {
+            let mut acc = segment_load_command.filesize;
             for data in &self.data {
                 if let Data::ZeroInit(size) = data.data {
-                    acc -= *size as u64;
+                    acc += *size as u64;
                 }
             }
             acc

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -697,11 +697,11 @@ impl<'a> Mach<'a> {
                     code.push(def);
                 }
                 DefinedDecl::Data(d) => {
-                    if d.get_datatype() == DataType::String {
-                        cstrings.push(def);
-                    } else if let Data::ZeroInit(size) = def.data {
+                    if let Data::ZeroInit(size) = def.data {
                         bss.push(def);
                         bss_size += size;
+                    } else if d.get_datatype() == DataType::String {
+                        cstrings.push(def);
                     } else {
                         data.push(def);
                     }

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -781,8 +781,17 @@ impl<'a> Mach<'a> {
         // FIXME: de-magic number these
         segment_load_command.initprot = 7;
         segment_load_command.maxprot = 7;
-        segment_load_command.filesize = self.segment.size();
-        segment_load_command.vmsize = segment_load_command.filesize;
+        segment_load_command.vmsize = self.segment.size();
+        // segment size, with __bss data sizes removed
+        segment_load_command.filesize = {
+            let mut acc = segment_load_command.vmsize;
+            for data in &self.data {
+                if let Data::ZeroInit(size) = data.data {
+                    acc -= *size as u64;
+                }
+            }
+            acc
+        };
         segment_load_command.fileoff = first_section_offset;
         debug!("Segment: {:#?}", segment_load_command);
 

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -1,6 +1,6 @@
 //! The Mach 32/64 bit backend for transforming an artifact to a valid, mach-o object file.
 
-use crate::artifact::{DataType, Decl, DefinedDecl, Definition, ImportKind, Reloc, SectionKind};
+use crate::artifact::{Data, DataType, Decl, DefinedDecl, Definition, ImportKind, Reloc, SectionKind};
 use crate::target::make_ctx;
 use crate::{Artifact, Ctx};
 

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -17,7 +17,8 @@ use string_interner::StringInterner;
 use target_lexicon::Architecture;
 
 use goblin::mach::constants::{
-    S_ATTR_DEBUG, S_ATTR_PURE_INSTRUCTIONS, S_ATTR_SOME_INSTRUCTIONS, S_CSTRING_LITERALS, S_REGULAR,
+    S_ATTR_DEBUG, S_ATTR_PURE_INSTRUCTIONS, S_ATTR_SOME_INSTRUCTIONS, S_CSTRING_LITERALS,
+    S_REGULAR, S_ZEROFILL,
 };
 use goblin::mach::cputype;
 use goblin::mach::header::{Header, MH_OBJECT, MH_SUBSECTIONS_VIA_SYMBOLS};
@@ -636,7 +637,7 @@ impl SegmentBuilder {
             BSS_SECTION_INDEX,
             &zero_init_data,
             0,
-            None,
+            Some(S_ZEROFILL),
             &mut align_pad_map,
         );
         for (idx, def) in custom_sections.iter().enumerate() {

--- a/tests/artifact.rs
+++ b/tests/artifact.rs
@@ -206,7 +206,8 @@ fn bss() {
     assert!(mach.len() < SIZE);
     match Object::parse(&mach).unwrap() {
         Object::Mach(Mach::Binary(mach)) => {
-            assert!(mach.symbols.unwrap().iter().next().is_some());
+            assert!(mach.segments.iter()
+            .any(|segment| segment.vmsize == SIZE as u64));
         }
         _ => panic!("emitted as MACHO but did not parse as MACHO"),
     }

--- a/tests/artifact.rs
+++ b/tests/artifact.rs
@@ -209,3 +209,12 @@ fn bss() {
         _ => panic!("emitted as MACHO but did not parse as MACHO")
     }
 }
+
+#[test]
+fn invalid_bss() {
+    let mut artifact = Artifact::new(triple!("x86_64"), "bss".into());
+    artifact.declare("my_func", Decl::function()).unwrap();
+    assert!(artifact.define_zero_init("my_func", 100).is_err());
+    artifact.declare("my_section", Decl::section(SectionKind::Data)).unwrap();
+    assert!(artifact.define_zero_init("my_section", 100).is_err());
+}

--- a/tests/artifact.rs
+++ b/tests/artifact.rs
@@ -205,7 +205,9 @@ fn bss() {
     file.write_all(&mach).unwrap();
     assert!(mach.len() < SIZE);
     match Object::parse(&mach).unwrap() {
-        Object::Mach(Mach::Binary(mach)) => assert!(!mach.symbols.unwrap().iter().next().is_some()),
+        Object::Mach(Mach::Binary(mach)) => {
+            assert!(mach.symbols.unwrap().iter().next().is_some());
+        }
         _ => panic!("emitted as MACHO but did not parse as MACHO"),
     }
 }

--- a/tests/artifact.rs
+++ b/tests/artifact.rs
@@ -183,8 +183,8 @@ fn vary_output_formats() {
 
 #[test]
 fn bss() {
+    use goblin::{mach::Mach, Object};
     use std::io::Write;
-    use goblin::{Object, mach::Mach};
     use target_lexicon::BinaryFormat;
 
     const SIZE: usize = 100_000_000_000_000;
@@ -197,7 +197,7 @@ fn bss() {
     assert!(elf.len() < SIZE);
     match Object::parse(&elf).unwrap() {
         Object::Elf(elf) => assert!(!elf.syms.is_empty()),
-        _ => panic!("emitted as ELF but did not parse as ELF")
+        _ => panic!("emitted as ELF but did not parse as ELF"),
     }
 
     let mach = artifact.emit_as(BinaryFormat::Macho).unwrap();
@@ -206,7 +206,7 @@ fn bss() {
     assert!(mach.len() < SIZE);
     match Object::parse(&mach).unwrap() {
         Object::Mach(Mach::Binary(mach)) => assert!(!mach.symbols.unwrap().iter().next().is_some()),
-        _ => panic!("emitted as MACHO but did not parse as MACHO")
+        _ => panic!("emitted as MACHO but did not parse as MACHO"),
     }
 }
 
@@ -215,6 +215,8 @@ fn invalid_bss() {
     let mut artifact = Artifact::new(triple!("x86_64"), "bss".into());
     artifact.declare("my_func", Decl::function()).unwrap();
     assert!(artifact.define_zero_init("my_func", 100).is_err());
-    artifact.declare("my_section", Decl::section(SectionKind::Data)).unwrap();
+    artifact
+        .declare("my_section", Decl::section(SectionKind::Data))
+        .unwrap();
     assert!(artifact.define_zero_init("my_section", 100).is_err());
 }

--- a/tests/artifact.rs
+++ b/tests/artifact.rs
@@ -206,8 +206,10 @@ fn bss() {
     assert!(mach.len() < SIZE);
     match Object::parse(&mach).unwrap() {
         Object::Mach(Mach::Binary(mach)) => {
-            assert!(mach.segments.iter()
-            .any(|segment| segment.vmsize == SIZE as u64));
+            assert!(mach
+                .segments
+                .iter()
+                .any(|segment| segment.vmsize == SIZE as u64));
         }
         _ => panic!("emitted as MACHO but did not parse as MACHO"),
     }

--- a/tests/artifact.rs
+++ b/tests/artifact.rs
@@ -180,3 +180,22 @@ fn vary_output_formats() {
     }
     */
 }
+
+#[test]
+fn bss() {
+    use goblin::Object;
+    use target_lexicon::BinaryFormat;
+
+    const SIZE: usize = 100_000_000_000_000;
+
+    let mut artifact = Artifact::new(triple!("x86_64"), "bss".into());
+    artifact.declare("my_data", Decl::data().global()).unwrap();
+    artifact.define_zero_init("my_data", SIZE).unwrap();
+
+    let elf = artifact.emit_as(BinaryFormat::Elf).unwrap();
+    assert!(elf.len() < SIZE);
+    match Object::parse(&elf).unwrap() {
+        Object::Elf(elf) => assert!(!elf.syms.is_empty()),
+        _ => panic!("emitted as ELF but did not parse as ELF")
+    }
+}


### PR DESCRIPTION
Allows defining zero-initialized data without allocating memory while writing the object file.

Closes #97.

Ongoing issues:

- [ ] [Need to test Mach-O parsing on a Mac](https://github.com/m4b/faerie/issues/97#issuecomment-533919277) (I don't own one)
- [x] Related: Need to fix [failing unit test](https://travis-ci.org/m4b/faerie/jobs/588284103#L451)/find a replacement. Additionally, tests shouldn't create random files in the current directory.
- [ ] It would be nice to emit a warning if `ZeroInit` data isn't marked as writable and allocatable, since [it will be marked that way by the ELF backend](https://github.com/jyn514/faerie/blob/bss/src/elf.rs#L323)
- [ ] Need to decide [if data sections are allowed to be `ZeroInit`](https://github.com/m4b/faerie/issues/97#issuecomment-533908225) - currently [they are not](https://github.com/jyn514/faerie/blob/bss/src/artifact.rs#L478)