### PR TITLE
Update target lexicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 Cargo.lock
 *~
 *#*
+mach.o

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.4"
 indexmap = "1"
 string-interner = "0.7.1"
 failure = "0.1"
-target-lexicon = "0.8.0"
+target-lexicon = "0.9.0"
 
 [dev-dependencies]
 env_logger = "0.6"

--- a/tests/elf.rs
+++ b/tests/elf.rs
@@ -260,7 +260,7 @@ fn decl_tests(tests: Vec<DeclTestCase>) {
 struct DeclTestCase {
     name: String,
     decl: Decl,
-    pred: Box<Fn(&Sym, &SectionHeader) -> Result<(), Error>>,
+    pred: Box<dyn Fn(&Sym, &SectionHeader) -> Result<(), Error>>,
 }
 impl DeclTestCase {
     fn new<D, F>(name: &str, decl: D, pred: F) -> Self


### PR DESCRIPTION
This updates target-lexicon, so we can update it in Cranelift as well. (Once that's in, it might be useful to publish a new version of this crate.)

Latest target-lexicon adds support for more architectures, and removes all the external dependencies, making it self-contained, lighter and faster to build.