### PR TITLE
Migrate from the `Fail` trait to `Error`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,9 @@ scroll = "0.10"
 log = "0.4"
 indexmap = "1"
 string-interner = "0.7.1"
-failure = "0.1"
+anyhow = "1.0"
 target-lexicon = "0.9.0"
+thiserror = "1.0"
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/examples/prototype.rs
+++ b/examples/prototype.rs
@@ -1,11 +1,9 @@
 extern crate env_logger;
 extern crate faerie;
-extern crate failure;
 extern crate goblin;
 extern crate structopt;
 extern crate target_lexicon;
 
-use failure::Error;
 use structopt::StructOpt;
 use target_lexicon::{Architecture, BinaryFormat, Environment, OperatingSystem, Triple, Vendor};
 
@@ -60,7 +58,7 @@ pub struct Args {
 }
 
 #[rustfmt::skip]
-fn run (args: Args) -> Result<(), Error> {
+fn run (args: Args) -> anyhow::Result<()> {
     let file = File::create(Path::new(&args.filename))?;
     let target = Triple {
         architecture: Architecture::X86_64,
@@ -186,7 +184,7 @@ fn run (args: Args) -> Result<(), Error> {
 }
 
 #[rustfmt::skip]
-fn deadbeef (args: Args) -> Result<(), Error> {
+fn deadbeef (args: Args) -> anyhow::Result<()> {
     let file = File::create(Path::new(&args.filename))?;
     let target = Triple {
         architecture: Architecture::X86_64,
@@ -362,7 +360,7 @@ fn deadbeef (args: Args) -> Result<(), Error> {
     Ok(())
 }
 
-fn link(name: &str, output: &str, linkline: &[String]) -> Result<(), Error> {
+fn link(name: &str, output: &str, linkline: &[String]) -> anyhow::Result<()> {
     //ld -e _start -I/usr/lib/ld-linux-x86-64.so.2 -L/usr/lib/ /usr/lib/crti.o /usr/lib/Scrt1.o /usr/lib/crtn.o test.o -lc -o test
     let child = Command::new("cc")
         .args(linkline)

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -13,7 +13,7 @@ use crate::{
     target::make_ctx,
     Ctx,
 };
-use failure::Error;
+use anyhow::Error;
 use goblin;
 
 use indexmap::IndexMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,6 @@ extern crate scroll;
 extern crate string_interner;
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate failure;
 extern crate target_lexicon;
 
 use goblin::container;

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -6,7 +6,7 @@ use crate::artifact::{
 use crate::target::make_ctx;
 use crate::{Artifact, Ctx};
 
-use failure::Error;
+use anyhow::Error;
 use indexmap::IndexMap;
 use scroll::ctx::SizeWith;
 use scroll::{IOwrite, Pwrite};

--- a/tests/elf.rs
+++ b/tests/elf.rs
@@ -3,11 +3,9 @@ extern crate goblin;
 extern crate scroll;
 #[macro_use]
 extern crate target_lexicon;
-#[macro_use]
-extern crate failure;
 
+use anyhow::{ensure, Error};
 use faerie::{Artifact, ArtifactBuilder, Decl, Link};
-use failure::Error;
 use goblin::elf::*;
 use std::str::FromStr;
 


### PR DESCRIPTION
This commit takes a similar migration path as proposed in
CraneStation/wasmtime#436 and shares much of the same motivation. The
intention here was originally spawned from using `anyhow` everywhere
inside of `wasmtime`!