### PR TITLE
Update example code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Emit some object files, at your leisure:
 let name = "test.o";
 let file = File::create(Path::new(name))?;
 let mut obj = ArtifactBuilder::new(triple!("x86_64-unknown-unknown-unknown-elf"))
-    .name(name)
+    .name(name.to_owned())
     .finish();
 
 // first we declare our symbolic references;
@@ -16,9 +16,9 @@ obj.declarations(
         ("deadbeef", Decl::function().into()),
         ("main",     Decl::function().global().into()),
         ("str.1",    Decl::cstring().into()),
-        ("DEADBEEF", Decl::data_import()),
-        ("printf",   Decl::function_import()),
-    ].into_iter().cloned()
+        ("DEADBEEF", Decl::data_import().into()),
+        ("printf",   Decl::function_import().into()),
+    ].iter().cloned()
 )?;
 
 // we now define our local functions and data


### PR DESCRIPTION
... so that it compiles. The change from `into_iter()` to `iter()` is to prevent the break from the potential future standard library update (https://github.com/rust-lang/rust/pull/65819)