### PR TITLE
make entire Artifact api return ArtifactError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ scroll = "0.10"
 log = "0.4"
 indexmap = "1"
 string-interner = "0.7.1"
-anyhow = "1.0"
 target-lexicon = "0.10.0"
 thiserror = "1.0"
 
 [dev-dependencies]
+anyhow = "1.0"
 env_logger = "0.7"
 structopt = "0.3"

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -13,7 +13,6 @@ use crate::{
     target::make_ctx,
     Ctx,
 };
-use anyhow::Error;
 use goblin;
 
 use indexmap::IndexMap;
@@ -1024,7 +1023,7 @@ impl<'a> Elf<'a> {
     }
 }
 
-pub fn to_bytes(artifact: &Artifact) -> Result<Vec<u8>, Error> {
+pub fn to_bytes(artifact: &Artifact) -> goblin::error::Result<Vec<u8>> {
     // TODO: make new fully construct the elf object, e.g., the definitions, imports, and links don't take self
     // this means that a call to new has a fully constructed object ready to marshal into bytes, similar to the mach backend
     let mut elf = Elf::new(&artifact);

--- a/src/mach.rs
+++ b/src/mach.rs
@@ -6,7 +6,6 @@ use crate::artifact::{
 use crate::target::make_ctx;
 use crate::{Artifact, Ctx};
 
-use anyhow::Error;
 use indexmap::IndexMap;
 use scroll::ctx::SizeWith;
 use scroll::{IOwrite, Pwrite};
@@ -749,7 +748,7 @@ impl<'a> Mach<'a> {
         header.sizeofcmds = sizeofcmds as u32;
         header
     }
-    pub fn write<T: Write + Seek>(self, file: T) -> Result<(), Error> {
+    pub fn write<T: Write + Seek>(self, file: T) -> Result<(), std::io::Error> {
         let mut file = BufWriter::new(file);
         // FIXME: this is ugly af, need cmdsize to get symtable offset
         // construct symtab command
@@ -1039,7 +1038,7 @@ fn build_relocations(segment: &mut SegmentBuilder, artifact: &Artifact, symtab: 
     }
 }
 
-pub fn to_bytes(artifact: &Artifact) -> Result<Vec<u8>, Error> {
+pub fn to_bytes(artifact: &Artifact) -> Result<Vec<u8>, std::io::Error> {
     let mach = Mach::new(&artifact);
     let mut buffer = Cursor::new(Vec::new());
     mach.write(&mut buffer)?;


### PR DESCRIPTION
an ArtifactError can be coerced into a anyhow::Error by consumers of this API, but the inverse is not true. There weren't many places where anyhow::Error was being used, and it was easy to add cases to ArtifactError to cover those cases.

We are trying to convert Lucet to use structured errors everywhere we can, and this helps us get rid of some of the very last we have left. The advantage as a consumer is we can write a thiserror variant like
`FaerieError(#[from] faerie::ArtifactError)` and then we automatically get all our Faerie errors in one variant, versus having to inspect the `anyhow::Error` by eye.